### PR TITLE
feat: add editable fields for max participants and waiting queue

### DIFF
--- a/src/main/java/org/montrealjug/billetterie/BilletterieApplication.java
+++ b/src/main/java/org/montrealjug/billetterie/BilletterieApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class BilletterieApplication {
 
 	public static void main(String[] args) {
+
 		SpringApplication.run(BilletterieApplication.class, args);
 	}
 

--- a/src/main/java/org/montrealjug/billetterie/EventsController.java
+++ b/src/main/java/org/montrealjug/billetterie/EventsController.java
@@ -121,7 +121,7 @@ public class EventsController {
         PresentationActivity presentationActivity;
         if (optionalActivity.isPresent()) {
             Activity activity = optionalActivity.get();
-            presentationActivity = new PresentationActivity(activity.getId(), activity.getTitle(), activity.getDescription(), activity.getStartTime().toLocalTime());
+            presentationActivity = new PresentationActivity(activity.getId(), activity.getTitle(), activity.getDescription(), activity.getMaxParticipants(), activity.getMaxWaitingQueue(), activity.getStartTime().toLocalTime());
         } else {
             throw new RuntimeException("Activity with id " + activityId + " not found");
         }
@@ -138,6 +138,8 @@ public class EventsController {
             Activity activity = optionalActivity.get();
             activity.setTitle(presentationActivity.title);
             activity.setDescription(presentationActivity.description);
+            activity.setMaxParticipants(presentationActivity.maxParticipants);
+            activity.setMaxWaitingQueue(presentationActivity.maxWaitingQueue);
 
             eventRepository.findById(eventId).ifPresent(event -> {
                 LocalDate date = event.getDate();
@@ -165,6 +167,8 @@ public class EventsController {
             Activity entity = new Activity();
             entity.setDescription(activity.description);
             entity.setTitle(activity.title);
+            entity.setMaxParticipants(activity.maxParticipants);
+            entity.setMaxWaitingQueue(activity.maxWaitingQueue);
 
             LocalDate date = event.getDate();
             LocalDateTime localDateTime = date.atTime(activity.time);
@@ -200,7 +204,7 @@ public class EventsController {
     private List<PresentationActivity> toIndexActivities(Set<Activity> activities) {
         List<PresentationActivity> indexActivities = new ArrayList<>();
         activities.forEach(activity -> {
-            PresentationActivity indexActivity = new PresentationActivity(activity.getId(), activity.getTitle(), activity.getDescription(), activity.getStartTime().toLocalTime());
+            PresentationActivity indexActivity = new PresentationActivity(activity.getId(), activity.getTitle(), activity.getDescription(), activity.getMaxParticipants(),activity.getMaxWaitingQueue(), activity.getStartTime().toLocalTime());
             indexActivities.add(indexActivity);
         });
         return indexActivities;
@@ -212,7 +216,7 @@ public class EventsController {
                                     List<PresentationActivity> activities, Boolean active) {
     }
 
-    public record PresentationActivity(Long id, @NotBlank String title, @NotBlank String description,
+    public record PresentationActivity(Long id, @NotBlank String title, @NotBlank String description, int maxParticipants, int maxWaitingQueue,
                                        LocalTime time) {
     }
 }

--- a/src/main/jte/activities-create-update.jte
+++ b/src/main/jte/activities-create-update.jte
@@ -34,6 +34,21 @@
                 <input type="time" id="time" name="time" required value="${activity!=null ? activity.time().toString() : ""}"
                        class="border border-gray-300 rounded-md px-4 py-2 focus:ring focus:ring-blue-300 focus:outline-none">
             </div>
+            <!-- Max Participants Input -->
+            <div class="mb-4">
+                <label for="maxParticipants" class="block text-gray-700 font-medium mb-2">Max Participants</label>
+                <input type="number" id="maxParticipants" name="maxParticipants" required min="1"
+                       value="${activity != null ? activity.maxParticipants() : 0}"
+                       class="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring focus:ring-blue-300 focus:outline-none">
+            </div>
+
+            <!-- Max Waiting Queue Input -->
+            <div class="mb-4">
+                <label for="maxWaitingQueue" class="block text-gray-700 font-medium mb-2">Max Waiting Queue</label>
+                <input type="number" id="maxWaitingQueue" name="maxWaitingQueue" required min="0"
+                       value="${activity != null ? activity.maxWaitingQueue() : 0}"
+                       class="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring focus:ring-blue-300 focus:outline-none">
+            </div>
             <!-- Submit Button -->
             <div class="text-center">
                 <button type="submit"

--- a/src/main/jte/events-list.jte
+++ b/src/main/jte/events-list.jte
@@ -54,6 +54,8 @@
                         <tr class="bg-gray-200">
                             <th class="border border-gray-300 px-4 py-2 text-left">Title</th>
                             <th class="border border-gray-300 px-4 py-2 text-left">Description</th>
+                            <th class="border border-gray-300 px-4 py-2 text-left">Max Seats</th>
+                            <th class="border border-gray-300 px-4 py-2 text-left">Max Waiting</th>
                             <th class="border border-gray-300 px-4 py-2 text-left">Start Time</th>
                             <th class="border border-gray-300 px-4 py-2 text-center">Actions</th>
                         </tr>
@@ -66,6 +68,9 @@
                         <tr>
                             <td class="border border-gray-300 px-4 py-2">${activity.title()}</td>
                             <td class="border border-gray-300 px-4 py-2">${activity.description()}</td>
+                            <td class="border border-gray-300 px-4 py-2">${activity.maxParticipants()}</td>
+                            <td class="border border-gray-300 px-4 py-2">${activity.maxWaitingQueue()}</td>
+
                             <td class="border border-gray-300 px-4 py-2">${activity.time().format(DateTimeFormatter.ofPattern("H:mm a"))}</td>
                             <td class="border border-gray-300 px-4 py-2 text-center space-x-2">
                                 <a href="/admin/events/${event.id()}/activities/${activity.id()}"


### PR DESCRIPTION
This Pull Request introduces two new editable fields in the activity creation and update form:

maxParticipants – maximum number of allowed participants

maxWaitingQueue – maximum size of the waiting list

These fields are now:

- visible and editable in the activity form
- 
- pre-filled when editing an existing activity
- 
- persisted to the database

**Technical Details**

- Updated the JTE template activities-create-update.jte to include the new fields
- 
- Extended PresentationActivity record to support maxParticipants and maxWaitingQueue
- 
- Adjusted EventsController to handle form binding and persistence of these fields
- 
- Updated the event details view to display the values in the activity list
- 
- Ensured clean JTE template compilation with updated parameter bindings