### PR TITLE
fix: ensure that entity that are equals have the same hashCode

### DIFF
--- a/src/main/java/org/montrealjug/billetterie/entity/Activity.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/Activity.java
@@ -84,6 +84,6 @@ public class Activity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, startTime, title, description, maxParticipants, maxWaitingQueue, participants);
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/org/montrealjug/billetterie/entity/Event.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/Event.java
@@ -79,7 +79,7 @@ public class Event {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, date, title, description, activities);
+        return Objects.hash(id);
     }
 
 }


### PR DESCRIPTION
A small pull request for an almost anecdotical issue: java contract for `equals` and `hashCode` states that object that are `equals` must have the same `hashCode`.

This `PR` changes the way `hashCode` is computed for `entities` were this part of the contract was not enforced.