### PR TITLE
chore: introduce property for JTE dependencies version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,10 @@
 		<url/>
 	</scm>
 	<properties>
+		<!-- general properties -->
 		<java.version>21</java.version>
+		<!-- third-party dependencies (outside of springboot BOM) -->
+		<jte.version>3.1.16</jte.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -52,13 +55,8 @@
 		</dependency>
 		<dependency>
 			<groupId>gg.jte</groupId>
-			<artifactId>jte</artifactId>
-			<version>3.1.16</version>
-		</dependency>
-		<dependency>
-			<groupId>gg.jte</groupId>
 			<artifactId>jte-spring-boot-starter-3</artifactId>
-			<version>3.1.16</version>
+			<version>${jte.version}</version>
 		</dependency>
 
 		<dependency>
@@ -112,7 +110,7 @@
 			<plugin>
 				<groupId>gg.jte</groupId>
 				<artifactId>jte-maven-plugin</artifactId>
-				<version>3.1.16</version>
+				<version>${jte.version}</version>
 				<executions>
 					<execution>
 						<id>jte-generate</id>


### PR DESCRIPTION
A small `PR` to introduce a `property` to drive `jte` stack dependencies version.
As the `maven` plugin and the `starter` must have the same version, we now are sure to always use correlated dependencies.

The explicit dependency declaration of `gg.jte:jte` has been removed as it is a transitive dependency of `gg.jte:jte-spring-boot-starter-3`.

Using `properties` to drive third-party dependencies version not managed in `springboot-bom` is helpful:
- open the possibility to check for new version locally via `mvn versions:display-property-updates`
- simplify reviews of `Dependabot` (or any other tool we would like to use) `PRs`