### PR TITLE
feat: order Participant in an Activity by their registration time to support waiting list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,14 @@
 					<imageBuilder>paketobuildpacks/builder-noble-java-tiny</imageBuilder>
 				</configuration>
 			</plugin>
+			<!-- needed to avoid WARN with Mockito (works for both IDE and mvn because we reuse Spring property) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/org/montrealjug/billetterie/entity/Activity.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/Activity.java
@@ -3,6 +3,7 @@ package org.montrealjug.billetterie.entity;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -16,8 +17,10 @@ public class Activity {
     private String description;
     private int maxParticipants;
     private int maxWaitingQueue;
-    @OneToMany
-    private Set<Participant> participants;
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "activity")
+    private Set<ActivityParticipant> participants = new HashSet<>();
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Event event;
 
     public long getId() {
         return id;
@@ -67,11 +70,19 @@ public class Activity {
         this.maxWaitingQueue = maxWaitingQueue;
     }
 
-    public Set<Participant> getParticipants() {
+    public Set<ActivityParticipant> getParticipants() {
         return participants;
     }
 
-    public void setParticipants(Set<Participant> participants) {
+    public Event getEvent() {
+        return event;
+    }
+
+    public void setEvent(Event event) {
+        this.event = event;
+    }
+
+    public void setParticipants(Set<ActivityParticipant> participants) {
         this.participants = participants;
     }
 

--- a/src/main/java/org/montrealjug/billetterie/entity/ActivityParticipant.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/ActivityParticipant.java
@@ -1,0 +1,85 @@
+package org.montrealjug.billetterie.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Entity
+public class ActivityParticipant implements Comparable<ActivityParticipant> {
+
+    @EmbeddedId
+    private ActivityParticipantKey activityParticipantKey = new ActivityParticipantKey();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("activityId")
+    private Activity activity;
+
+    @ManyToOne
+    @MapsId("participantId")
+    private Participant participant;
+
+    @Column(nullable = false, updatable = false)
+    private Instant registrationTime = Instant.now();
+
+    public ActivityParticipantKey getActivityParticipantKey() {
+        return activityParticipantKey;
+    }
+
+    public void setActivityParticipantKey(ActivityParticipantKey activityParticipantKey) {
+        this.activityParticipantKey = activityParticipantKey;
+    }
+
+    public Activity getActivity() {
+        return activity;
+    }
+
+    public void setActivity(Activity activity) {
+        this.activity = activity;
+    }
+
+    public Participant getParticipant() {
+        return participant;
+    }
+
+    public void setParticipant(Participant participant) {
+        this.participant = participant;
+    }
+
+    public Instant getRegistrationTime() {
+        return registrationTime;
+    }
+
+    public void setRegistrationTime(Instant registrationTime) {
+        this.registrationTime = registrationTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ActivityParticipant that)) {
+            return false;
+        }
+        return Objects.equals(activityParticipantKey, that.activityParticipantKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(activityParticipantKey);
+    }
+
+    @Override
+    public int compareTo(ActivityParticipant o) {
+        var activityComp = Long.compare(this.activityParticipantKey.getActivityId(),  o.activityParticipantKey.getActivityId());
+        if (activityComp == 0) {
+            return this.registrationTime.compareTo(o.registrationTime);
+        } else {
+            return activityComp;
+        }
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/entity/ActivityParticipantKey.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/ActivityParticipantKey.java
@@ -1,0 +1,41 @@
+package org.montrealjug.billetterie.entity;
+
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+
+@Embeddable
+public class ActivityParticipantKey {
+
+    private long activityId;
+    private long participantId;
+
+    public long getActivityId() {
+        return activityId;
+    }
+
+    public void setActivityId(long activityId) {
+        this.activityId = activityId;
+    }
+
+    public long getParticipantId() {
+        return participantId;
+    }
+
+    public void setParticipantId(long participantId) {
+        this.participantId = participantId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ActivityParticipantKey that)) {
+            return false;
+        }
+        return activityId == that.activityId && participantId == that.participantId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(activityId, participantId);
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/entity/Booker.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/Booker.java
@@ -2,6 +2,7 @@ package org.montrealjug.billetterie.entity;
 
 import jakarta.persistence.*;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -12,8 +13,8 @@ public class Booker {
     private String firstName;
     private String lastName;
 
-    @OneToMany
-    private Set<Participant> participants;
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "booker")
+    private Set<Participant> participants = new HashSet<>();
 
     public String getEmail() {
         return email;

--- a/src/main/java/org/montrealjug/billetterie/entity/Event.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/Event.java
@@ -18,7 +18,7 @@ public class Event {
     private boolean active;
     @Column(columnDefinition = "TEXT")
     private String description;
-    @OneToMany
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
     private Set<Activity> activities = new HashSet<>();
 
     public long getId() {

--- a/src/main/java/org/montrealjug/billetterie/entity/Participant.java
+++ b/src/main/java/org/montrealjug/billetterie/entity/Participant.java
@@ -2,6 +2,10 @@ package org.montrealjug.billetterie.entity;
 
 import jakarta.persistence.*;
 
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
 @Entity
 public class Participant {
     @Id
@@ -10,6 +14,52 @@ public class Participant {
     private String firstName;
     private String lastName;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY,  optional = false)
+    @JoinColumn(name="booker_email", nullable = false)
     private Booker booker;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public Booker getBooker() {
+        return booker;
+    }
+
+    public void setBooker(Booker booker) {
+        this.booker = booker;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Participant that)) {
+            return false;
+        }
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/org/montrealjug/billetterie/ui/EventsController.java
+++ b/src/main/java/org/montrealjug/billetterie/ui/EventsController.java
@@ -169,13 +169,13 @@ public class EventsController {
             entity.setTitle(activity.title());
             entity.setMaxParticipants(activity.maxParticipants());
             entity.setMaxWaitingQueue(activity.maxWaitingQueue());
+            entity.setEvent(event);
 
             LocalDate date = event.getDate();
             LocalDateTime localDateTime = date.atTime(activity.time());
 
             entity.setStartTime(localDateTime);
             event.getActivities().add(entity);
-            activityRepository.save(entity);
             eventRepository.save(event);
 
         });

--- a/src/test/java/org/montrealjug/billetterie/repository/ActivityRepositoryTest.java
+++ b/src/test/java/org/montrealjug/billetterie/repository/ActivityRepositoryTest.java
@@ -1,0 +1,131 @@
+package org.montrealjug.billetterie.repository;
+
+import org.junit.jupiter.api.Test;
+import org.montrealjug.billetterie.entity.Activity;
+import org.montrealjug.billetterie.entity.ActivityParticipant;
+import org.montrealjug.billetterie.entity.Booker;
+import org.montrealjug.billetterie.entity.Event;
+import org.montrealjug.billetterie.entity.Participant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class ActivityRepositoryTest {
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    BookerRepository bookerRepository;
+
+    @Autowired
+    ActivityRepository activityRepository;
+
+    @Test
+    void registration_of_activity_participants_should_be_ordered_by_registration_time() {
+        // create first booker with 2 participants
+        var firstBooker = new Booker();
+        firstBooker.setFirstName("First");
+        firstBooker.setLastName("Booker");
+        firstBooker.setEmail("firstBooker@test.org");
+        var firstPart = new Participant();
+        firstPart.setFirstName("First");
+        firstPart.setLastName("Participant");
+        firstPart.setBooker(firstBooker);
+        firstBooker.getParticipants().add(firstPart);
+        firstBooker = bookerRepository.save(firstBooker);
+        // jpa does not set the @Id in the associated entity, inefficient, but we're in a test 🤷
+        firstBooker.getParticipants()
+                .stream()
+                .findFirst()
+                .map(Participant::getId)
+                .ifPresent(firstPart::setId);
+        // as we have a Set and @Id will be set after persistence,
+        // we can't add multiple new Participant to a Booker in one shot
+        var secondPart = new Participant();
+        secondPart.setFirstName("Second");
+        secondPart.setLastName("Participant");
+        secondPart.setBooker(firstBooker);
+        firstBooker.getParticipants().add(secondPart);
+        firstBooker = bookerRepository.save(firstBooker);
+        // jpa does not set the @Id in the associated entity, inefficient, but we're in a test 🤷
+        firstBooker.getParticipants()
+                .stream()
+                .filter(p -> p.getId() != firstPart.getId())
+                .findFirst()
+                .map(Participant::getId)
+                .ifPresent(secondPart::setId);
+
+        // create second Booker with 1 Participant
+        var secondBooker = new Booker();
+        secondBooker.setFirstName("Second");
+        secondBooker.setLastName("Booker");
+        secondBooker.setEmail("secondBooker@test.org");
+        var thirdPart = new Participant();
+        thirdPart.setFirstName("Third");
+        thirdPart.setLastName("Participant");
+        thirdPart.setBooker(secondBooker);
+        secondBooker.getParticipants().add(thirdPart);
+        secondBooker = bookerRepository.save(secondBooker);
+        // jpa does not set the @Id in the associated entity, inefficient, but we're in a test 🤷
+        secondBooker.getParticipants()
+                .stream()
+                .findFirst()
+                .map(Participant::getId)
+                .ifPresent(thirdPart::setId);
+
+        // create the Event
+        var event = new Event();
+        event.setDate(LocalDate.now().plusDays(2L));
+        event.setActive(true);
+        event.setDescription("Description");
+        event.setTitle("Title");
+        event = eventRepository.save(event);
+
+        // create the Activity in the Event
+        var activity = new Activity();
+        activity.setTitle("Title");
+        activity.setDescription("Description");
+        activity.setMaxParticipants(12);
+        activity.setMaxWaitingQueue(120);
+        activity.setStartTime(LocalDateTime.now().plusDays(2L));
+        activity.setEvent(event);
+        activity = activityRepository.save(activity);
+
+        // create `registrations`
+        var firstRegistration = new ActivityParticipant();
+        firstRegistration.setActivity(activity);
+        firstRegistration.setParticipant(thirdPart);
+        activity.getParticipants().add(firstRegistration);
+        activity = activityRepository.save(activity);
+
+        var secondRegistration = new ActivityParticipant();
+        secondRegistration.setActivity(activity);
+        secondRegistration.setParticipant(firstPart);
+        activity.getParticipants().add(secondRegistration);
+        activity = activityRepository.save(activity);
+
+        var thirdRegistration = new ActivityParticipant();
+        thirdRegistration.setActivity(activity);
+        thirdRegistration.setParticipant(secondPart);
+        activity.getParticipants().add(thirdRegistration);
+        activity = activityRepository.save(activity);
+
+        var savedActivity = activityRepository.findById(activity.getId());
+        assertThat(savedActivity).isPresent();
+        var participantIdList = savedActivity.get()
+                .getParticipants()
+                .stream()
+                .sorted() // `natural` sorting, using `ActivityParticipant#compareTo`
+                .map(ActivityParticipant::getParticipant)
+                .map(Participant::getId)
+                .toList();
+
+        assertThat(participantIdList).containsExactly(thirdPart.getId(), firstPart.getId(), secondPart.getId());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,11 +1,16 @@
-# required to have the Postgres dependency up and running during tests
 spring:
+  # required to have the Postgres dependency up and running during tests
   docker:
     compose:
       enabled: true
       file: compose.yaml
       skip:
         in-tests: false
+  # required for model creation during tests
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 # required to have the templates compiled
 gg:


### PR DESCRIPTION
The easiest way to maintain an ordered List of `Participant` tu support waiting list logic is to order them by time of creation (`registrationTime`).

This `PR` introduces an `ActivityParticipant` entity to represent the association and hold the `registrationTime`.
`ActivityParticipant` is `Comparable` and order `Participant` for an `Activity` by their `registrationTime`.

The `test` `ActivityRepositoryTest` creates two `Booker`, each with different `Participant`, an `Activity` and then register the `Participant` to this `Activity` in a given order.
The `DB` is then read and the ordering of `ActivityParticipant` is verified.

Other technical changes:
- add the configuration for `Mockito` in the `pom.xml` to avoid warning on dynamic agent loading
- add `cascade = CascadeType.ALL` on `Activity` and `Booker` in order to save associated `Participant` and `ActivityParticipant` by saving the holding `Entity`
- add fetch - FetchType.LAZY in `Participant` to not load the `Booker` by default
- add bidirectionnal mapping in `JPA` to ensure that the created model is as expected

After a discussion outside of this `PR`, as stated, this `PR` also changes the underlying `sql model`.
More precisely, it normalizes this model, enforcing the usage of `PKs` in associations (instead of association tables that were used previously).

This is a breaking change, and previously saved data should be flushed and recreated following the new model.

The changes concerning the model normalization can be split from the one regarding the ordering of Participant registration in Activity, but as changes on the model needed to be done for this feature, making all the changes in the same `PR` made sense.

closes #17 