### PR TITLE
feat: add Email module and first template for Booking confirmation email

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ And then:
 
 `./mvnw spring-boot:run`
 
+### Using development profiles
+
+To ease local development, two profiles are available:
+- `local`: for day to day development
+- `local-mail`: to test sent emails locally (it's a group that loads `local` and `mailhog` profiles in the expected order) (see [email module documentation](./src/main/java/org/montrealjug/billetterie/email/README.md#how-to-test-locally) for more)
+
+You can set your desired profile on the command line:
+
+```shell
+./mvnw spring-boot:run -Dspring-boot.run.profiles=local
+``` 
+or 
+```shell
+./mvnw spring-boot:run -Dspring-boot.run.profiles=local-mail
+```
+This can also be done in your `IDE` configuration.
+
 ### Issues you could encounter
 
 If the database schema changed, because of JPA entities, the safest way to rebuild everything is... to delete your DB!

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ services:
     profiles:
       - ""
       - "test"
+      - "mailhog"
 
 #  billetterie:
 ##    image: 'registry.fly.io/billetterie:deployment-01JRVD2DCA9K1BA7YE25RCSH6T'
@@ -28,3 +29,15 @@ services:
       PGADMIN_DEFAULT_PASSWORD: secret
     profiles:
       - ""
+      - "mailhog"
+
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "21025:1025"
+      - "28025:8025"
+    profiles:
+      - "mailhog"
+
+  # to use profiles with docker compose: docker compose --profile mailhog up/down
+  # or let Spring do the job by using the `local-mail` Spring profile

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<!-- general properties -->
 		<java.version>21</java.version>
 		<!-- third-party dependencies (outside of springboot BOM) -->
+        <jsoup.version>1.19.1</jsoup.version>
 		<jte.version>3.2.0</jte.version>
 	</properties>
 	<dependencies>
@@ -79,6 +80,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>${jsoup.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<!-- general properties -->
 		<java.version>21</java.version>
 		<!-- third-party dependencies (outside of springboot BOM) -->
-        <jsoup.version>1.19.1</jsoup.version>
+		<jsoup.version>1.19.1</jsoup.version>
 		<jte.version>3.2.0</jte.version>
 	</properties>
 	<dependencies>

--- a/src/main/java/org/montrealjug/billetterie/email/EmailConfiguration.java
+++ b/src/main/java/org/montrealjug/billetterie/email/EmailConfiguration.java
@@ -1,0 +1,93 @@
+package org.montrealjug.billetterie.email;
+
+import gg.jte.TemplateEngine;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.validation.annotation.Validated;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(EmailConfiguration.EmailProperties.class)
+@EnableAsync
+class EmailConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmailConfiguration.class);
+
+    @Bean
+    EmailSender emailSender(
+            @Autowired(required = false) JavaMailSender javaMailSender, // useful for tests
+            EmailProperties emailProperties
+    ) {
+        final EmailSender emailSender;
+        if (javaMailSender != null && emailProperties.mode != EmailMode.NO_OP) {
+            emailSender = new SmtpEmailSender(javaMailSender, emailProperties);
+        } else {
+            LOGGER.warn("no-op EmailSender configured, emails will be sent to the console as logs");
+            emailSender = EmailSender.NO_OP;
+        }
+        return emailSender;
+    }
+
+    @Bean
+    EmailService emailService(
+            EmailSender emailSender,
+            TemplateEngine templateEngine,
+            ResourceBundleMessageSource messageSource
+    ) {
+        var emailWriter = new EmailWriter(templateEngine, messageSource);
+        return new EmailService(emailSender, emailWriter);
+    }
+
+    @Validated
+    @ConfigurationProperties(prefix = "app.mail")
+    record EmailProperties(
+            @DefaultValue("SMTP")
+            EmailMode mode,
+            @Valid
+            @NotNull
+            @NestedConfigurationProperty
+            EmailAddress from,
+            @Valid
+            @NotNull
+            @NestedConfigurationProperty
+            EmailAddress replyTo
+    ) {}
+
+    enum EmailMode {
+        NO_OP, SMTP
+    }
+
+    record EmailAddress(
+            @Email
+            @NotBlank
+            String address,
+            @NotBlank
+            String name
+    ) {
+        InternetAddress asInternetAddress() {
+            try {
+                return new InternetAddress(address, name, StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                // should never happen...
+                throw new IllegalArgumentException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/email/EmailModel.java
+++ b/src/main/java/org/montrealjug/billetterie/email/EmailModel.java
@@ -1,0 +1,135 @@
+package org.montrealjug.billetterie.email;
+
+import jakarta.mail.internet.InternetAddress;
+import org.montrealjug.billetterie.entity.ActivityParticipant;
+import org.montrealjug.billetterie.entity.Booker;
+import org.montrealjug.billetterie.entity.Event;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
+import java.util.Locale;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class EmailModel {
+
+    // to use in email templates via Email implementation utility methods
+    private static final DateTimeFormatter FR_DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+            .withLocale(Locale.CANADA_FRENCH);
+    private static final DateTimeFormatter EN_DATE_FORMAT = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+            .withLocale(Locale.CANADA_FRENCH);
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("H:mm a")
+            .withLocale(Locale.CANADA_FRENCH);
+    private static final DateTimeFormatter ISO_DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .withLocale(Locale.CANADA_FRENCH);
+    private static final DateTimeFormatter ISO_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+            .withLocale(Locale.CANADA_FRENCH);
+
+    private EmailModel() {
+        // model class
+    }
+
+    public enum EmailType {
+
+        AFTER_BOOKING;
+
+        public String subjectKey() {
+            return this.name().toLowerCase();
+        }
+
+        public String plainTextTemplate() {
+            return "email/%s-plain.jte".formatted(this.name().toLowerCase());
+        }
+
+        public String htmlTextTemplate() {
+            return "email/%s-html.jte".formatted(this.name().toLowerCase());
+        }
+    }
+
+    public interface Email {
+
+        EmailType type();
+        InternetAddress to();
+
+        default String formatDateFr(Temporal temporal) {
+            return FR_DATE_FORMAT.format(temporal);
+        }
+
+        default String formatDateEn(Temporal temporal) {
+            return EN_DATE_FORMAT.format(temporal);
+        }
+
+        default String formatTime(Temporal temporal) {
+            return TIME_FORMAT.format(temporal);
+        }
+
+        default String formatForDateTimeAttribute(Temporal temporal) {
+            if (temporal.isSupported(ChronoField.HOUR_OF_DAY)) {
+                return ISO_DATE_TIME_FORMAT.format(temporal);
+            } else if (temporal.isSupported(ChronoField.DAY_OF_MONTH)) {
+                return ISO_DATE_FORMAT.format(temporal);
+            } else {
+                throw new UnsupportedOperationException("Unsupported temporal type: " + temporal.getClass());
+            }
+        }
+
+        static Email afterBooking(
+                Booker booker,
+                Event event,
+                Set<ActivityParticipant> participants
+        ) {
+            return new AfterBookingEmail(booker, event, participants);
+        }
+
+        private static InternetAddress fromBooker(Booker booker) {
+            try {
+                return new InternetAddress(
+                        booker.getEmail(),
+                        "%s %s".formatted(booker.getFirstName(), booker.getLastName()),
+                        StandardCharsets.UTF_8.name()
+                );
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+    }
+
+    // must be public to be used in jte template
+    public record AfterBookingEmail(
+            Booker booker,
+            Event event,
+            Set<ActivityParticipant> participants
+    ) implements Email {
+
+        public AfterBookingEmail(Booker booker, Event event, Set<ActivityParticipant> participants) {
+            this.booker = booker;
+            this.event = event;
+            this.participants = participants instanceof SortedSet ? participants : new TreeSet<>(participants);
+        }
+
+        @Override
+        public EmailType type() {
+            return EmailType.AFTER_BOOKING;
+        }
+
+        @Override
+        public InternetAddress to() {
+            return Email.fromBooker(booker);
+        }
+
+        public String registrationLink() {
+            return "https://placeholder_for_registration_link.test";
+        }
+    }
+
+    record EmailToSend(
+            InternetAddress to,
+            String subject,
+            String plainText,
+            String html
+    ) {}
+}

--- a/src/main/java/org/montrealjug/billetterie/email/EmailSender.java
+++ b/src/main/java/org/montrealjug/billetterie/email/EmailSender.java
@@ -1,0 +1,17 @@
+package org.montrealjug.billetterie.email;
+
+import jakarta.mail.MessagingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.montrealjug.billetterie.email.EmailModel.EmailToSend;
+
+interface EmailSender {
+
+    Logger LOGGER = LoggerFactory.getLogger(EmailSender.class.getName());
+
+    void send(EmailToSend emailToSend) throws MessagingException;
+
+    EmailSender NO_OP = emailToSend -> LOGGER.info("sending email: {}", emailToSend);
+
+}

--- a/src/main/java/org/montrealjug/billetterie/email/EmailService.java
+++ b/src/main/java/org/montrealjug/billetterie/email/EmailService.java
@@ -1,0 +1,38 @@
+package org.montrealjug.billetterie.email;
+
+import org.montrealjug.billetterie.email.EmailModel.Email;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+
+import java.util.Collection;
+
+public class EmailService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmailService.class);
+
+    private final EmailSender emailSender;
+    private final EmailWriter emailWriter;
+
+    EmailService(EmailSender emailSender, EmailWriter emailWriter) {
+        this.emailSender = emailSender;
+        this.emailWriter = emailWriter;
+    }
+
+    @Async
+    public void sendEmail(Email email) {
+        try {
+            var emailToSend = this.emailWriter.write(email);
+            this.emailSender.send(emailToSend);
+        } catch (Exception e) {
+            LOGGER.error("error while sending email", e);
+        }
+    }
+
+    @Async
+    public void sendEmails(Collection<? extends Email> emails) {
+        for (Email context : emails) {
+            this.sendEmail(context);
+        }
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/email/EmailWriter.java
+++ b/src/main/java/org/montrealjug/billetterie/email/EmailWriter.java
@@ -1,0 +1,39 @@
+package org.montrealjug.billetterie.email;
+
+import gg.jte.TemplateEngine;
+import gg.jte.output.StringOutput;
+import org.montrealjug.billetterie.email.EmailModel.Email;
+import org.montrealjug.billetterie.email.EmailModel.EmailToSend;
+import org.springframework.context.support.ResourceBundleMessageSource;
+
+import java.util.Locale;
+
+class EmailWriter {
+
+    private final TemplateEngine templateEngine;
+    private final ResourceBundleMessageSource messageSource;
+
+    EmailWriter(TemplateEngine templateEngine, ResourceBundleMessageSource messageSource) {
+        this.templateEngine = templateEngine;
+        this.messageSource = messageSource;
+    }
+
+    EmailToSend write(Email email) {
+        var emailType = email.type();
+        var subject = this.messageSource.getMessage(emailType.subjectKey(), null, Locale.CANADA_FRENCH);
+        var plainText = this.writeTemplate(emailType.plainTextTemplate(), email);
+        var htmlText = this.writeTemplate(emailType.htmlTextTemplate(), email);
+        return new EmailToSend(
+                email.to(),
+                subject,
+                plainText,
+                htmlText
+        );
+    }
+
+    private String writeTemplate(String templateName, Email email) {
+        var templateOutput = new StringOutput();
+        templateEngine.render(templateName, email, templateOutput);
+        return templateOutput.toString();
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/email/README.md
+++ b/src/main/java/org/montrealjug/billetterie/email/README.md
@@ -1,0 +1,126 @@
+# Email module
+
+Encapsulate logic to send emails.
+
+## How to use it in code to send email(s)
+
+Inject an instance of `EmailService`.
+
+Build the `Email`(s) using one of the `static` factory methods and call `sendEmail` or `sendEmails`.
+
+```java
+import org.montrealjug.billetterie.email.EmailModel.Email;
+import org.montrealjug.billetterie.email.EmailService;
+import org.montrealjug.billetterie.entity.ActivityParticipant;
+import org.montrealjug.billetterie.entity.Event;
+import org.montrealjug.billetterie.entity.Participant;
+
+class MyService {
+
+ private final EmailService emailService;
+
+ //...
+ public void doStuff(Booker booker, Event event, Set<ActivityParticipant> participants) {
+  // ...
+  var email = Email.afterBooking(booker, event, participants);
+  emailService.sendEmail(email);
+  //...
+ }
+ //...
+}
+```
+Both `sendEmail` and batch `sendEmails` are asynchronous, so they will return immediately while logging any `Exception`.
+
+## How to add an EmailType (aka a new email model)
+
+The model is exposed in a *model* `class`: [`EmailModel`](./EmailModel.java).
+
+It contains an `enum` `EmailType` that enforces a convention to link an `EmailType` with two `jte` templates,
+one for `text/plain`, another for `text/html`, and a `key` in the `messages.properties` default bundle for the email subject. 
+
+This convention is that for a member `MY_EMAIL_TYPE` of the `enum` `EmailType`:
+- the key in the bundle for the subject is `my_email_type`
+- the `text/html` template will be resolved in the default `jte` package at `email/my_email_type-html.jte` 
+- the `text/plain` template will be resolved in the default `jte` package at `email/my_email_type-plain.jte`
+
+To provide a `context` to your template, you must define an implementation of `Email`.
+
+This implementation will provide an `EmailType` via its 
+ `type()` method.  
+Each template (`text/html` and `text/plain`) associated with this `EmailType` will be called with the `Email` instance as `@param` to build the content of the email.  
+The email will be sent to the `InternetAddress` returned by the `to()` method of your implementation.
+
+The easiest way to define an implementation is to use a `record` to wrap the data you need as it is done with `AfterBookingEmail` 
+in the *model* `class` [`EmailModel`](./EmailModel.java).  
+To avoid using each `Email` implementation outside of this module, add a `static` factory `method` as `Email.afterBooking()`.  
+This implementation must be `public` for the import in the template to work (see [`after_booking-plain.jte`](../.././../../../jte/email/after_booking-plain.jte)).
+
+To have coherent `html` emails, a common `layout` is available at [`email_html_layout.jte.jte`](../.././../../../jte/layouts/email_html_layout.jte).  
+This common `layout` has 4 parameters:
+- a mandatory `title` for the `html` `title` (in the `head` of the document)
+- a mandatory `h1`... for the `h1` of the document
+- a mandatory `mainContent`: this is a `Content` from `jte` API that will be inlined in the `main` part of the document
+- an optional `additionalHeadContent`: this is a `Content` from `jte` API that will be inlined, if defined, at the end of the `head` tag in the document
+
+See the [`Content` part of the `jte` documentation for more](https://jte.gg/syntax/#content).
+
+An exemple of usage can be found in [`after_booking-html.jte`](../.././../../../jte/email/after_booking-html.jte).
+
+While not being mandatory, the use of this common `layout` is encouraged to:
+- ease development and maintenance of new templates
+- ensure a graphic coherence between our emails
+
+### How to test your new Email type
+
+The test class [`EmailWriterTest`](../.././../../../../test/java/org/montrealjug/billetterie/email/EmailWriterTest.java) is built to ease validation of template executions.
+
+To add your new `EmailType` in the test suite, build an instance of your `Email` and add it in the `Stream` returned by the `emails` method of the test.
+
+The generated content will be validated against:
+- a `test resource` file `my_email_type.html` for `text/html` (content will be compared after `Jsoup.parse(content).html()` to avoid formatting issues)
+- a `test resource` file `my_email_type.txt` for `text/plain` (content will be trimmed before comparaison to avoid formatting issues)
+
+## How to test locally
+
+The `local` profile deactivate email emission by setting the property `app.mail.mode` to `no-op`.  
+Running the app with the `local` profile will send emails to the `console` via logs.
+
+Another profile has been added for both `spring` and `docker compose` configuration: `mailhog`.  
+Because this `mailhog` profile should be used on top of the `local` profile and [some limitations on dynamic profile registration](https://docs.spring.io/spring-boot/reference/features/profiles.html) in `SpringBoot`,
+a [`group`](https://docs.spring.io/spring-boot/reference/features/profiles.html#features.profiles.groups) `local-mail` is available to set everything up in one shot:
+```shell
+./mvnw spring-boot:run -Dspring-boot.run.profiles=local-mail
+```
+
+When activated in `spring` (from the command line or from your `IDE`) this `local-mail` profile will:
+- activate the `local` and the `mailhog` profile in the expected order
+- start a [`MailHog`](https://github.com/mailhog/MailHog) container listening for `SMTP` on port `21025` and exposing its web-ui on port `28025`
+- configure the app to send emails to this `MailHog` container
+- exposes a `rest controller` to send emails on demand (see [`TestMailController`](./TestMailController.java))
+
+Calling the [`TestMailController`](./TestMailController.java):
+```shell
+http POST http://localhost:8080/test/email/after-booking
+```
+will send an email that can be seen in `MailHog` web-ui at [`http://localhost:28025`](http://localhost:28025).
+
+The web-ui lets us check the conformity of the email.
+
+**BUT** html email is a big mess! 
+
+Especially `Outlook (classic)` is a massive **PAIN** because it uses `Word` html rendering engine (😱🤦🤷).  
+This situation has spawned an entire industry of tools and services to ensure that `Outlook (classic)` behaves as expected.  
+Don't go through this rabbit hole, there's nothing valuable to learn there.  
+If you're lucky enough to never have suffered the `IE` pain to code webapps, you can experiment it with `html` email and `Outlook (classic)`. Trigger warning for everyone that has suffered the `IE` pain coding webapps a decade ago...
+The only good news is that `Outlook (new)` almost follows standards...
+
+To check rendering in an email client:
+- send an email to the `MailHog` container (you can use the [`TestMailController`](./TestMailController.java))
+- open this email in [`MailHog` web-ui](http://localhost:28025) (select the email in the list)
+- go to the `Source` tab, copy its content to a local `.eml` file (i.e. `my-test.eml`).
+- open this `.eml` in a local mail client and check the rendering in this client.
+
+You can edit the `html` part of the `.eml` directly with your favorite text editor, save and check again in your local mail client.
+When you're satisfied with the result, backport your changes in the associated `jte` template, update your expected `html` file in the test resources, check again the result via `MailHog`...
+
+You know understand the rant about `Outlook` html rendering...

--- a/src/main/java/org/montrealjug/billetterie/email/README.md
+++ b/src/main/java/org/montrealjug/billetterie/email/README.md
@@ -64,7 +64,7 @@ This common `layout` has 4 parameters:
 
 See the [`Content` part of the `jte` documentation for more](https://jte.gg/syntax/#content).
 
-An exemple of usage can be found in [`after_booking-html.jte`](../.././../../../jte/email/after_booking-html.jte).
+An example of usage can be found in [`after_booking-html.jte`](../.././../../../jte/email/after_booking-html.jte).
 
 While not being mandatory, the use of this common `layout` is encouraged to:
 - ease development and maintenance of new templates
@@ -111,7 +111,7 @@ The web-ui lets us check the conformity of the email.
 Especially `Outlook (classic)` is a massive **PAIN** because it uses `Word` html rendering engine (😱🤦🤷).  
 This situation has spawned an entire industry of tools and services to ensure that `Outlook (classic)` behaves as expected.  
 Don't go through this rabbit hole, there's nothing valuable to learn there.  
-If you're lucky enough to never have suffered the `IE` pain to code webapps, you can experiment it with `html` email and `Outlook (classic)`. Trigger warning for everyone that has suffered the `IE` pain coding webapps a decade ago...
+If you're lucky enough to never have suffered the `IE` pain to code webapps, you can experiment it with `html` email and `Outlook (classic)`. Trigger warning for everyone who has suffered the `IE` pain coding webapps a decade ago...
 The only good news is that `Outlook (new)` almost follows standards...
 
 To check rendering in an email client:
@@ -123,4 +123,4 @@ To check rendering in an email client:
 You can edit the `html` part of the `.eml` directly with your favorite text editor, save and check again in your local mail client.
 When you're satisfied with the result, backport your changes in the associated `jte` template, update your expected `html` file in the test resources, check again the result via `MailHog`...
 
-You know understand the rant about `Outlook` html rendering...
+You now understand the rant about `Outlook` html rendering...

--- a/src/main/java/org/montrealjug/billetterie/email/SmtpEmailSender.java
+++ b/src/main/java/org/montrealjug/billetterie/email/SmtpEmailSender.java
@@ -1,0 +1,34 @@
+package org.montrealjug.billetterie.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import org.montrealjug.billetterie.email.EmailConfiguration.EmailProperties;
+import org.montrealjug.billetterie.email.EmailModel.EmailToSend;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import java.nio.charset.StandardCharsets;
+
+class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender javaMailSender;
+    private final InternetAddress from;
+    private final InternetAddress replyTo;
+
+    SmtpEmailSender(JavaMailSender javaMailSender, EmailProperties emailProperties) {
+        this.javaMailSender = javaMailSender;
+        this.from = emailProperties.from().asInternetAddress();
+        this.replyTo = emailProperties.replyTo().asInternetAddress();
+    }
+
+    public void send(EmailToSend email) throws MessagingException {
+        var msg = this.javaMailSender.createMimeMessage();
+        var helper = new MimeMessageHelper(msg, true, StandardCharsets.UTF_8.name());
+        helper.setTo(email.to());
+        helper.setFrom(this.from);
+        helper.setReplyTo(this.replyTo);
+        helper.setSubject(email.subject());
+        helper.setText(email.plainText(), email.html());
+        this.javaMailSender.send(msg);
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/email/TestMailController.java
+++ b/src/main/java/org/montrealjug/billetterie/email/TestMailController.java
@@ -1,0 +1,135 @@
+package org.montrealjug.billetterie.email;
+
+import org.montrealjug.billetterie.entity.Activity;
+import org.montrealjug.billetterie.entity.ActivityParticipant;
+import org.montrealjug.billetterie.entity.Booker;
+import org.montrealjug.billetterie.entity.Event;
+import org.montrealjug.billetterie.entity.Participant;
+import org.montrealjug.billetterie.repository.ActivityRepository;
+import org.montrealjug.billetterie.repository.BookerRepository;
+import org.montrealjug.billetterie.repository.EventRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.stream.Collectors;
+
+/**
+ * This class is only for local dev convenience to send email to the local `MailHog` container
+ * and validate/work on email templates
+ * Ideally:
+ * - each EmailType should have its dedicated method
+ * - each method should be idempotent
+ */
+@RestController
+@Profile("mailhog")
+@RequestMapping("/test/email")
+public class TestMailController {
+
+    private final EventRepository eventRepository;
+    private final ActivityRepository activityRepository;
+    private final BookerRepository bookerRepository;
+    private final EmailService emailService;
+
+    public TestMailController(
+            EventRepository eventRepository,
+            ActivityRepository activityRepository,
+            BookerRepository bookerRepository,
+            EmailService emailService
+    ) {
+        this.eventRepository = eventRepository;
+        this.activityRepository = activityRepository;
+        this.bookerRepository = bookerRepository;
+        this.emailService = emailService;
+    }
+
+    @PostMapping("/after-booking")
+    public ResponseEntity<Void> sendAfterBookingEmail() {
+        // saving everything in DB is not needed, but it does not hurt 🤷😉 and is a cheap way to test stuffs...
+        // this is not the most efficient code, but it's for local dev testing after all...
+        var event  = eventRepository.findByActiveIsTrue()
+                .orElseGet(() -> {
+                    var newEvent = new Event();
+                    newEvent.setTitle("Test Event for mail notification");
+                    newEvent.setDescription("Test Event for mail notification description");
+                    newEvent.setActive(true);
+                    newEvent.setDate(LocalDate.now().plusDays(7L));
+                    return eventRepository.save(newEvent);
+                });
+
+        var testActivityTitle = "Test Activity for mail notification";
+        var activity = event.getActivities()
+                .stream()
+                .filter(a -> a.getTitle().equals(testActivityTitle))
+                .findFirst()
+                .orElseGet(() -> {
+                    var newActivity = new Activity();
+                    newActivity.setTitle(testActivityTitle);
+                    newActivity.setDescription("Test Activity for mail notification description");
+                    newActivity.setMaxParticipants(12);
+                    newActivity.setMaxWaitingQueue(123);
+                    newActivity.setStartTime(event.getDate().atTime(9, 30));
+                    newActivity.setEvent(event);
+                    newActivity = activityRepository.save(newActivity);
+                    event.getActivities().add(newActivity);
+                    return newActivity;
+                });
+
+        var testEmail = "booker@test.org";
+        var booker = bookerRepository.findById(testEmail)
+                .orElseGet(() -> {
+                    var newBooker = new Booker();
+                    newBooker.setFirstName("Booker First Name");
+                    newBooker.setLastName("Booker Last Name");
+                    newBooker.setEmail("booker@test.org");
+                    newBooker = bookerRepository.save(newBooker);
+                    var firstPart = new Participant();
+                    firstPart.setFirstName("FirstParticipant First Name");
+                    firstPart.setLastName("FirstParticipant Last Name");
+                    firstPart.setBooker(newBooker);
+                    newBooker.getParticipants().add(firstPart);
+                    newBooker = bookerRepository.save(newBooker);
+                    var secondPart = new Participant();
+                    secondPart.setFirstName("SecondParticipant First Name");
+                    secondPart.setLastName("SecondParticipant Last Name");
+                    secondPart.setBooker(newBooker);
+                    newBooker.getParticipants().add(secondPart);
+                    bookerRepository.save(newBooker);
+                    // to get the ids in the created Participants
+                    return bookerRepository.findById(testEmail)
+                            .orElseThrow(() -> new IllegalStateException("we should have found the just created booker!"));
+                });
+
+        var bookerParticipantIds = booker.getParticipants()
+                .stream()
+                .map(Participant::getId)
+                .collect(Collectors.toSet());
+        var participants = activity.getParticipants()
+                .stream()
+                .filter(ap -> bookerParticipantIds.contains(ap.getParticipant().getId()))
+                .collect(Collectors.toSet());
+
+        if (participants.isEmpty()) {
+            booker.getParticipants().forEach(participant -> {
+                var registration = new ActivityParticipant();
+                registration.setParticipant(participant);
+                registration.setActivity(activity);
+                activityRepository.save(activity);
+            });
+            // to get all ids set properly
+            var updatedActivity = activityRepository.findById(activity.getId())
+                    .orElseThrow(() -> new IllegalStateException("we should have found the updated activity!"));
+            updatedActivity.getParticipants()
+                    .stream()
+                    .filter(ap -> bookerParticipantIds.contains(ap.getParticipant().getId()))
+                    .forEach(participants::add);
+        }
+
+        var email = EmailModel.Email.afterBooking(booker, event, participants);
+        this.emailService.sendEmail(email);
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/repository/BookerRepository.java
+++ b/src/main/java/org/montrealjug/billetterie/repository/BookerRepository.java
@@ -3,5 +3,5 @@ package org.montrealjug.billetterie.repository;
 import org.montrealjug.billetterie.entity.Booker;
 import org.springframework.data.repository.CrudRepository;
 
-public interface BookerRepository extends CrudRepository<Booker, Long> {
+public interface BookerRepository extends CrudRepository<Booker, String> {
 }

--- a/src/main/jte/email/after_booking-html.jte
+++ b/src/main/jte/email/after_booking-html.jte
@@ -1,0 +1,183 @@
+@import org.montrealjug.billetterie.email.EmailModel.AfterBookingEmail
+@import org.montrealjug.billetterie.entity.ActivityParticipant
+
+@param AfterBookingEmail context
+!{var title = "Confirmation d'inscription à un événement Devoxx4Kids Québec/Booking confirmation for a Devoxx4Kids Québec event";}
+!{var h1 = "Inscription confirmée!";}
+@template.layouts.email_html_layout(
+  title = title,
+  h1 = h1,
+  additionalHeadContent = @`
+  <style>
+    td.participant {
+      padding: 0 0 0.8em 1em;
+    }
+    table.participant {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      margin: 0;
+      line-height: 1.6em;
+    }
+  </style>
+  `,
+  mainContent = @`
+  <table class="main-table" lang="fr-CA" xml:lang="fr-CA">
+    <tbody>
+    <tr>
+      <td>
+        Bonjour ${context.booker().getFirstName()} ${context.booker().getLastName()},
+      </td>
+    </tr>
+    <tr>
+      <td>Nous vous confirmons votre inscription pour l'événement</td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        <strong>${context.event().getTitle()}</strong>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        programmé le <time datetime="${context.formatForDateTimeAttribute(context.event().getDate())}">${context.formatDateFr(context.event().getDate())}</time>.
+      </td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        Lors de cet événement,
+      </td>
+    </tr>
+    @for (ActivityParticipant registration: context.participants())
+      <tr>
+        <td class="participant">
+          <table class="participant">
+            <tr>
+              <td>
+                ${registration.getParticipant().getFirstName()} ${registration.getParticipant().getLastName()}
+              </td>
+            </tr>
+            <tr>
+              <td>participera à l'activité:</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>${registration.getActivity().getTitle()}</strong>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                démarrant à <time datetime="${context.formatForDateTimeAttribute(registration.getActivity().getStartTime())}">${context.formatTime(registration.getActivity().getStartTime())}</time>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    @endfor
+    <tr>
+      <td style="padding: 0;">Vous pouvez modifier votre inscription en utilisant le lien suivant:</td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        <a href="${context.registrationLink()}"
+           class="link-button"
+           target="_blank"
+        >
+          @raw
+          <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+          Gérer mon inscription
+          <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+          @endraw
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td class="italic">On s'y voit bientôt!</td>
+    </tr>
+    <tr>
+      <td class="italic">L'équipe Devoxx4Kids Québec</td>
+    </tr>
+    </tbody>
+  </table>
+  <p class="english-version">English version:</p>
+  <table class="main-table" lang="en-CA" xml:lang="en-CA">
+    <tbody>
+    <tr>
+      <td>
+        Hi ${context.booker().getFirstName()} ${context.booker().getLastName()},
+      </td>
+    </tr>
+    <tr>
+      <td>We confirm your activity booking for the event</td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        <strong>${context.event().getTitle()}</strong>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        scheduled on <time datetime="${context.formatForDateTimeAttribute(context.event().getDate())}">${context.formatDateEn(context.event().getDate())}</time>.
+      </td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        During this event,
+      </td>
+    </tr>
+    @for (ActivityParticipant registration: context.participants())
+      <tr>
+        <td class="participant">
+          <table class="participant">
+            <tr>
+              <td>
+                ${registration.getParticipant().getFirstName()} ${registration.getParticipant().getLastName()}
+              </td>
+            </tr>
+            <tr>
+              <td>will attend the activity:</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>${registration.getActivity().getTitle()}</strong>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                starting at <time datetime="${context.formatForDateTimeAttribute(registration.getActivity().getStartTime())}">${context.formatTime(registration.getActivity().getStartTime())}</time>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    @endfor
+    <tr>
+      <td style="padding: 0;">You can manage your booking using the following link:</td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        <a href="${context.registrationLink()}"
+           class="link-button"
+           target="_blank"
+        >
+          @raw
+          <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+          Manage my booking
+          <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+          @endraw
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td class="italic">See you soon there!</td>
+    </tr>
+    <tr>
+      <td class="italic">The Devoxx4Kids Québec team</td>
+    </tr>
+    <!-- ghost line to avoid a strange border in Outlook classic 🤷-->
+    <tr>
+      <td style="padding: 0; line-height: 1em;">&nbsp;</td>
+    </tr>
+    </tbody>
+  </table>
+`)
+

--- a/src/main/jte/email/after_booking-plain.jte
+++ b/src/main/jte/email/after_booking-plain.jte
@@ -1,0 +1,34 @@
+@import org.montrealjug.billetterie.email.EmailModel.AfterBookingEmail
+@import org.montrealjug.billetterie.entity.ActivityParticipant
+
+@param AfterBookingEmail context
+Devoxx4Kids Québec, confirmation d'inscription à une activité (English version will follow):
+
+Bonjour ${context.booker().getFirstName()} ${context.booker().getLastName()},
+Nous vous confirmons votre inscription pour l'événement Devoxx4kids ${context.event().getTitle()} le ${context.formatDateFr(context.event().getDate())}.
+Lors de cet événement,
+@for (ActivityParticipant registration : context.participants())
+  ${registration.getParticipant().getFirstName()} ${registration.getParticipant().getLastName()}
+  participera à l'activité:
+  ${registration.getActivity().getTitle()} démarrant à ${context.formatTime(registration.getActivity().getStartTime())}
+@endfor
+Vous pouvez modifier votre inscription en utilisant le lien suivant: ${context.registrationLink()}
+
+On s'y voit bientôt!
+L'équipe Devoxx4Kids Québec.
+
+English version:
+Devoxx4Kids Québec, activity booking confirmation:
+
+Hi ${context.booker().getFirstName()} ${context.booker().getLastName()},
+We confirm your activity booking for the Devoxx4Kids event ${context.event().getTitle()} on ${context.formatDateEn(context.event().getDate())}.
+During this event,
+@for (ActivityParticipant registration : context.participants())
+  ${registration.getParticipant().getFirstName()} ${registration.getParticipant().getLastName()}
+  will attend the activity:
+  ${registration.getActivity().getTitle()} starting at ${context.formatTime(registration.getActivity().getStartTime())}
+@endfor
+You can manage your booking using the following link: ${context.registrationLink()}
+
+See you soon there!
+The Devoxx4Kids Québec team.

--- a/src/main/jte/layouts/email_html_layout.jte
+++ b/src/main/jte/layouts/email_html_layout.jte
@@ -1,0 +1,192 @@
+@param String title
+@param String h1
+@param gg.jte.Content mainContent
+@param gg.jte.Content additionalHeadContent = null
+<!DOCTYPE html>
+<html lang="fr-CA">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html charset=UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>${title}</title>
+  <style>
+    body {
+      padding: 0.2em 1em;
+      font-family: 'Helvetica Neue', Helvetica, Arial, 'sans-serif';
+      box-sizing: border-box;
+      background-color: #777;
+      mso-line-height-rule: exactly;
+    }
+    h1 {
+      margin: 0;
+    }
+    table.layout {
+      border: none;
+      border-radius: 4px;
+      background-color: white;
+      width: 600px;
+      margin: auto;
+      border-collapse: collapse;
+    }
+    td.layout {
+      padding: 1em;
+      mso-line-height-rule: exactly;
+    }
+    span.italic-grey {
+      font-style: italic;
+      color: #777;
+    }
+    p.english-version {
+      font-style: italic;
+      color: #777;
+      display: inline-block;
+      margin: 2em 0 1em 0;
+    }
+    table.header {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      border-radius: 0;
+      margin: 0;
+    }
+    table.main-table {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border-radius: 0;
+      border: none;
+      margin: 0;
+      line-height: 1.8em;
+    }
+    table.footer {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      border-radius: 0;
+      margin: 0;
+      font-size: 0.8em;
+      color: #777;
+      width: 100%;
+    }
+    td.with-top-bottom-padding {
+      padding: 0.8em 0;
+    }
+    td.italic {
+      font-style: italic;
+      padding: 0;
+    }
+    td.footer-left {
+      font-style: italic;
+    }
+    td.footer-right {
+      text-align: right;
+    }
+    a.link-button {
+      font-size: 0.8em;
+      background-color: #f0690a;
+      text-decoration: none;
+      padding: 0.2em 0.8em;
+      color: white;
+      display: inline-block;
+      border-radius: 4px;
+      mso-padding-alt: 0;
+      text-underline-color: #f0690a;
+      border: 2px solid #f0690a;
+    }
+    a.link-button:hover {
+      background-color: white;
+      color: #f0690a;
+    }
+  </style>
+  @if (additionalHeadContent != null)
+    ${additionalHeadContent}
+  @endif
+</head>
+<body>
+  <table class="layout">
+    <tr>
+      <td class="layout">
+        <header>
+          <table class="header">
+            <tbody>
+              <tr>
+                <td>
+                  <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2014/06/D4K_QUEBEC_1000px.png"
+                       alt="Devoxx4Kids Québec logo"
+                       width="560"
+                       style="width: 560px; margin: auto;"
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="italic-grey">Devoxx4Kids Québec</span>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 1.8em 0;">
+                  <h1>${h1}</h1>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span class="italic-grey">The English version will follow</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </header>
+      </td>
+    </tr>
+    <tr>
+      <td class="layout">
+        <main>
+          ${mainContent}
+        </main>
+      </td>
+    </tr>
+    <tr>
+      <td class="layout">
+        <footer>
+          <table class="footer">
+            <tbody>
+              <tr>
+                <td class="footer-left">
+                  &copy; ${java.time.LocalDate.now().getYear()} Québec – All rights reserved
+                </td>
+                <td class="footer-right">
+                  <table style="border: none; border-spacing: 0; border-collapse: collapse; margin: auto 0 auto auto; width: 100px;">
+                    <tbody>
+                      <tr>
+                        <td>
+                          <a href="https://www.facebook.com/Devoxx4KidsQC/">
+                            <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2024/11/facebook-300x300.png"
+                                 alt="Facebook logo"
+                                 width="32"
+                                 height="32"
+                                 style="display: inline; width: 32px;"
+                            />
+                          </a>
+                        </td>
+                        <td>
+                          <a href="https://www.linkedin.com/company/devoxx4kids-quebec/?viewAsMember=true">
+                            <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2024/11/linkedin-300x300.png"
+                                 alt="LinkedIn logo"
+                                 width="32"
+                                 height="32"
+                                 style="display: inline; width: 32px;"
+                            />
+                          </a>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </footer>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,3 +1,11 @@
+logging:
+  level:
+    org:
+      springframework:
+        boot:
+          actuate:
+            mail: error
+
 gg:
   jte:
     use-precompiled-templates: off

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,10 @@
+gg:
+  jte:
+    use-precompiled-templates: off
+    development-mode: on
+spring:
+  mail:
+    test-connection: off
+app:
+  mail:
+    mode: no-op

--- a/src/main/resources/application-mailhog.yml
+++ b/src/main/resources/application-mailhog.yml
@@ -1,0 +1,20 @@
+# profile to be used with `local` but with a MailHog SMTP server
+# set the appropriate docker compose profile and the mail properties
+# to send emails to the MailHog container
+spring:
+  docker:
+    compose:
+      profiles:
+        active: "mailhog"
+  mail:
+    host: localhost
+    port: 21025
+    properties:
+      mail.smtp.auth: false
+      mail.smtp.starttls.enabled: false
+      mail.smtp.starttls.required: false
+    test-connection: on
+
+app:
+  mail:
+    mode: smtp

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,24 @@ spring:
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  mail:
+    host: ${MAIL_SERVER:in-v3.mailjet.com}
+    username: ${MAIL_USER:}
+    password: ${MAIL_PASSWORD:}
+    port: 587
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enabled: true
+      mail.smtp.starttls.required: true
+      #mail.smtp.debug: true # uncomment to have SMTP exchanges logged to the console
+    # switch to on when credentials are confirmed
+    # if `on`, the app will fail to launch if the connection to the SMTP server fails
+    test-connection: off
+  messages:
+    fallback-to-system-locale: false
+  profiles:
+    group:
+      local-mail: local,mailhog
 
 management:
   endpoints:
@@ -26,3 +44,11 @@ management:
     health:
       show-details: always
 
+app:
+  mail:
+    from:
+      address: quebec@devoxx4kids.org
+      name: Devoxx4Kids Québec
+    reply-to:
+      address: quebec@devoxx4kids.org
+      name: Devoxx4Kids Québec

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+after_booking=Merci d'avoir réservé une activité avec Devoxx4Kids Québec! / Thanks for booking an activity with Devoxx4Kids Québec!

--- a/src/test/java/org/montrealjug/billetterie/email/EmailConfigurationTest.java
+++ b/src/test/java/org/montrealjug/billetterie/email/EmailConfigurationTest.java
@@ -1,0 +1,106 @@
+package org.montrealjug.billetterie.email;
+
+import gg.jte.TemplateEngine;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.montrealjug.billetterie.email.EmailConfiguration.EmailProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class EmailConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(EmailConfiguration.class)
+            .withBean(TemplateEngine.class, () -> mock(TemplateEngine.class))
+            .withBean(ResourceBundleMessageSource.class, () -> mock(ResourceBundleMessageSource.class));
+
+    @Test
+    void emailConfiguration_should_provide_NO_OP_EmailSender_if_no_JavaMailSender_bean_is_available() {
+        contextRunner
+                .withPropertyValues(VALID_PROPERTIES)
+                .run(context -> assertThat(context)
+                        .hasSingleBean(EmailService.class)
+                        .hasSingleBean(EmailSender.class)
+                        .doesNotHaveBean(JavaMailSender.class)
+                        .getBean(EmailSender.class).isSameAs(EmailSender.NO_OP)
+                );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SMTP"})
+    @EmptySource
+    void emailConfiguration_should_provide_a_SmtpEmailSender_if_mode_is_SMTP_or_not_defined(String mode) {
+        contextRunner
+                .withPropertyValues(VALID_PROPERTIES)
+                .withPropertyValues("app.mail.mode=" + mode)
+                .withBean(JavaMailSender.class, () -> mock(JavaMailSender.class))
+                .run(context -> assertThat(context)
+                        .hasSingleBean(EmailService.class)
+                        .hasSingleBean(EmailSender.class)
+                        .getBean(EmailSender.class).isInstanceOf(SmtpEmailSender.class)
+                );
+    }
+
+    @Test
+    void emailConfiguration_should_provide_NO_OP_EmailSender_if_mode_is_NO_OP() {
+        contextRunner
+                .withPropertyValues(VALID_PROPERTIES)
+                .withPropertyValues("app.mail.mode=no-op")
+                .withBean(JavaMailSender.class, () -> mock(JavaMailSender.class))
+                .run(context -> assertThat(context)
+                        .hasSingleBean(EmailService.class)
+                        .hasSingleBean(EmailSender.class)
+                        .getBean(EmailSender.class).isSameAs(EmailSender.NO_OP)
+                );
+    }
+
+    @Test
+    void emailConfiguration_should_validate_EmailProperties() {
+        var missingProperties = new String[] {
+                VALID_PROPERTIES[0],
+                VALID_PROPERTIES[2],
+                VALID_PROPERTIES[3]
+        };
+        contextRunner.withPropertyValues(missingProperties)
+                .run(context -> assertThat(context).hasFailed());
+
+        var invalidProperties = new String[] {
+                "this_is_not_a_valid_email",
+                VALID_PROPERTIES[1],
+                VALID_PROPERTIES[2],
+                VALID_PROPERTIES[3]
+        };
+        contextRunner.withPropertyValues(invalidProperties)
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    @Test
+    void valid_EmailProperties_should_have_valid_asInternetAddress() {
+        contextRunner
+                .withPropertyValues(VALID_PROPERTIES)
+                .run(context -> {
+                    var emailProperties = context.getBean(EmailProperties.class);
+                    var from = emailProperties.from();
+                    assertThat(from.asInternetAddress())
+                            .satisfies(ia ->  assertThat(ia.getAddress()).isEqualTo(from.address()))
+                            .satisfies(ia ->  assertThat(ia.getPersonal()).isEqualTo(from.name()));
+                    var replyTo = emailProperties.replyTo();
+                    assertThat(replyTo.asInternetAddress())
+                            .satisfies(ia ->  assertThat(ia.getAddress()).isEqualTo(replyTo.address()))
+                            .satisfies(ia ->  assertThat(ia.getPersonal()).isEqualTo(replyTo.name()));
+                });
+    }
+
+    private static final String[] VALID_PROPERTIES = {
+            "app.mail.from.address=from@test.org",
+            "app.mail.from.name=From Test",
+            "app.mail.reply-to.address=reply-to@test.org",
+            "app.mail.reply-to.name=Reply To Test",
+    };
+}

--- a/src/test/java/org/montrealjug/billetterie/email/EmailServiceTest.java
+++ b/src/test/java/org/montrealjug/billetterie/email/EmailServiceTest.java
@@ -1,0 +1,65 @@
+package org.montrealjug.billetterie.email;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.montrealjug.billetterie.email.EmailModel.Email;
+import org.montrealjug.billetterie.email.EmailModel.EmailToSend;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock
+    SmtpEmailSender emailSender;
+
+    @Mock
+    EmailWriter emailWriter;
+
+    @Mock
+    Email email;
+
+    @Mock
+    EmailToSend emailToSend;
+
+    EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        emailService = new EmailService(emailSender, emailWriter);
+    }
+
+    @Test
+    void sendEmail_should_call_emailSender_send_with_the_result_of_emailWriter_write() throws Exception {
+        when(emailWriter.write(email)).thenReturn(emailToSend);
+
+        emailService.sendEmail(email);
+
+        verify(emailWriter).write(email);
+        verify(emailSender).send(emailToSend);
+    }
+
+    @Test
+    void sendEmail_should_catch_any_exception_thrown_by_emailWriter() {
+        var exception = new NullPointerException("...null?");
+        when(emailWriter.write(email)).thenThrow(exception);
+
+        assertThatCode(() -> emailService.sendEmail(email)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void sendEmail_should_catch_any_exception_thrown_by_emailSender() throws Exception {
+        when(emailWriter.write(email)).thenReturn(emailToSend);
+        var exception = new NullPointerException("...null?");
+        doThrow(exception).when(emailSender).send(emailToSend);
+
+        assertThatCode(() -> emailService.sendEmail(email)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/montrealjug/billetterie/email/EmailTestHelper.java
+++ b/src/test/java/org/montrealjug/billetterie/email/EmailTestHelper.java
@@ -1,0 +1,33 @@
+package org.montrealjug.billetterie.email;
+
+import org.montrealjug.billetterie.email.EmailConfiguration.EmailAddress;
+import org.montrealjug.billetterie.email.EmailConfiguration.EmailMode;
+import org.montrealjug.billetterie.email.EmailConfiguration.EmailProperties;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class EmailTestHelper {
+
+    static EmailProperties emailProperties() {
+        var from = new EmailAddress("from@test.org", "From Test");
+        var replyTo = new EmailAddress("reply-to@test.org", "Reply To Test");
+        return new EmailProperties(
+                EmailMode.NO_OP,
+                from,
+                replyTo
+        );
+    }
+
+    static String loadResourceContent(String resourceName) {
+        var resource = EmailTestHelper.class.getClassLoader().getResource(resourceName);
+        if (resource == null) {
+            throw new IllegalArgumentException(resourceName + " not found");
+        }
+        try {
+            return Files.readString(Path.of(resource.toURI()));
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/test/java/org/montrealjug/billetterie/email/EmailWriterTest.java
+++ b/src/test/java/org/montrealjug/billetterie/email/EmailWriterTest.java
@@ -1,0 +1,104 @@
+package org.montrealjug.billetterie.email;
+
+import gg.jte.TemplateEngine;
+import org.jsoup.Jsoup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.montrealjug.billetterie.email.EmailModel.Email;
+import org.montrealjug.billetterie.entity.Activity;
+import org.montrealjug.billetterie.entity.ActivityParticipant;
+import org.montrealjug.billetterie.entity.Booker;
+import org.montrealjug.billetterie.entity.Event;
+import org.montrealjug.billetterie.entity.Participant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.support.ResourceBundleMessageSource;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EmailWriterTest {
+
+    @Autowired
+    TemplateEngine templateEngine;
+
+    @Autowired
+    ResourceBundleMessageSource messageSource;
+
+    EmailWriter emailWriter;
+
+    @BeforeEach
+    void setUp() {
+        emailWriter = new EmailWriter(templateEngine, messageSource);
+    }
+
+    @ParameterizedTest
+    @MethodSource("emails")
+    void write_should_write_expected_emails(Email email) {
+        var emailToSend = emailWriter.write(email);
+
+        assertThat(emailToSend.to()).isEqualTo(email.to());
+        var expectedSubject = messageSource.getMessage(email.type().name().toLowerCase(), null, Locale.CANADA_FRENCH);
+        assertThat(emailToSend.subject()).isEqualTo(expectedSubject);
+        var expectedPlainTextFile = "email/%s.txt".formatted(email.type().name().toLowerCase());
+        var plainTextContent = EmailTestHelper.loadResourceContent(expectedPlainTextFile);
+        assertThat(emailToSend.plainText().trim()).isEqualTo(plainTextContent.trim());
+        var expectedHtmlFile = "email/%s.html".formatted(email.type().name().toLowerCase());
+        var expectedHtmlContent = EmailTestHelper.loadResourceContent(expectedHtmlFile);
+        assertThat(Jsoup.parse(emailToSend.html()).html()).isEqualTo(Jsoup.parse(expectedHtmlContent).html());
+    }
+
+    static Stream<Arguments> emails() {
+        return Stream.of(
+                Arguments.of(forAfterBooking())
+        );
+    }
+
+    static Email forAfterBooking() {
+        var event = new Event();
+        event.setDate(LocalDate.of(2025, 4, 15));
+        event.setTitle("Test Event");
+        var activity = new Activity();
+        activity.setId(1L);
+        activity.setTitle("Test Activity");
+        activity.setStartTime(LocalDateTime.of(2025, 4, 15, 13, 25, 0));
+        var booker = new Booker();
+        booker.setEmail("booker@test.org");
+        booker.setFirstName("booker-firstName-é");
+        booker.setLastName("booker-lastName-ü");
+        var firstParticipant = new Participant();
+        firstParticipant.setBooker(booker);
+        firstParticipant.setFirstName("part-firstName-é");
+        firstParticipant.setLastName("part-lastName-ü");
+        firstParticipant.setId(1L);
+        var firstActivityParticipant = new ActivityParticipant();
+        firstActivityParticipant.setActivity(activity);
+        firstActivityParticipant.setParticipant(firstParticipant);
+        firstActivityParticipant.getActivityParticipantKey().setActivityId(activity.getId());
+        firstActivityParticipant.getActivityParticipantKey().setParticipantId(firstParticipant.getId());
+        var secondParticipant = new Participant();
+        secondParticipant.setBooker(booker);
+        secondParticipant.setFirstName("second-firstName-é");
+        secondParticipant.setLastName("second-lastName-ü");
+        secondParticipant.setId(2L);
+        var secondActivityParticipant = new ActivityParticipant();
+        secondActivityParticipant.setActivity(activity);
+        secondActivityParticipant.setParticipant(secondParticipant);
+        secondActivityParticipant.getActivityParticipantKey().setActivityId(activity.getId());
+        secondActivityParticipant.getActivityParticipantKey().setParticipantId(secondParticipant.getId());
+        var participants = Set.of(firstActivityParticipant, secondActivityParticipant);
+        return Email.afterBooking(
+                booker,
+                event,
+                participants
+        );
+    }
+}

--- a/src/test/java/org/montrealjug/billetterie/email/SmtpEmailSenderTest.java
+++ b/src/test/java/org/montrealjug/billetterie/email/SmtpEmailSenderTest.java
@@ -1,0 +1,175 @@
+package org.montrealjug.billetterie.email;
+
+import jakarta.mail.Address;
+import jakarta.mail.Multipart;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.montrealjug.billetterie.email.EmailConfiguration.EmailProperties;
+import org.montrealjug.billetterie.email.EmailModel.EmailToSend;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SmtpEmailSenderTest {
+
+    private static final EmailToSend TEST_DATA = testData();
+    private static final EmailProperties EMAIL_PROPERTIES = EmailTestHelper.emailProperties();
+
+    @Mock
+    JavaMailSender javaMailSender;
+
+    @Mock
+    MimeMessage mimeMessage;
+
+    SmtpEmailSender emailSender;
+
+    @BeforeEach
+    void setUp() {
+        when(javaMailSender.createMimeMessage())
+                .thenReturn(mimeMessage)
+                .thenReturn(mock(MimeMessage.class));
+        doNothing().when(javaMailSender).send(same(mimeMessage));
+        lenient().doThrow(new IllegalArgumentException("unexpected message send!"))
+                .when(javaMailSender).send(not(same(mimeMessage)));
+        this.emailSender = new SmtpEmailSender(javaMailSender, EMAIL_PROPERTIES);
+    }
+
+    @Test
+    void test_mock_setup() {
+        // first call of this method should return our mock
+        assertThat(javaMailSender.createMimeMessage()).isSameAs(mimeMessage);
+        // second call of this method should NOT return our mock (just to ensure it's been called once)
+        assertThat(javaMailSender.createMimeMessage()).isNotNull().isNotSameAs(mimeMessage);
+        // calling send with another message than our mock should throw expected Exception
+        assertThatThrownBy(() -> this.javaMailSender.send(mock(MimeMessage.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("unexpected message send!");
+        // calling send with our mock message should not throw any Exception
+        assertThatCode(() -> this.javaMailSender.send(mimeMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void send_should_set_expected_from_address() throws Exception {
+        emailSender.send(TEST_DATA);
+
+        var captor = ArgumentCaptor.forClass(InternetAddress.class);
+        verify(mimeMessage).setFrom(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(EMAIL_PROPERTIES.from().asInternetAddress());
+    }
+
+    @Test
+    void send_should_set_expected_to_address() throws Exception {
+        emailSender.send(TEST_DATA);
+
+        var captor = ArgumentCaptor.forClass(InternetAddress.class);
+        verify(mimeMessage).setRecipient(eq(MimeMessage.RecipientType.TO), captor.capture());
+        assertThat(captor.getValue()).isSameAs(TEST_DATA.to());
+    }
+
+    @Test
+    void send_should_set_expected_reply_to_address() throws Exception {
+        emailSender.send(TEST_DATA);
+
+        var captor = ArgumentCaptor.forClass(Object.class);
+        verify(mimeMessage).setReplyTo((Address[]) captor.capture());
+        var addresses = (Address[]) captor.getValue();
+        assertThat(addresses).containsExactly(EMAIL_PROPERTIES.replyTo().asInternetAddress());
+    }
+
+    @Test
+    void send_should_set_expected_subject() throws Exception {
+        emailSender.send(TEST_DATA);
+
+        var captor = ArgumentCaptor.forClass(String.class);
+        verify(mimeMessage).setSubject(captor.capture(), eq(StandardCharsets.UTF_8.name()));
+        assertThat(captor.getValue()).isSameAs(TEST_DATA.subject());
+    }
+
+    @Test
+    void send_should_add_expected_body_part() throws Exception {
+        emailSender.send(TEST_DATA);
+
+        var captor = ArgumentCaptor.forClass(Multipart.class);
+        verify(mimeMessage).setContent(captor.capture());
+        // this is the `rootPart` part of our email
+        var rootPart = captor.getValue();
+        // `rootPart` should have a contentType starting by `multipart/mixed;` to be valid
+        assertThat(rootPart.getContentType()).startsWith("multipart/mixed;");
+        // our `rootPart` should have a contentType containing `boundary="..."` to be valid
+        assertThat(rootPart.getContentType()).containsPattern("boundary=\".*\"");
+        // our `rootPart` should contain one part, our `bodyPart` that should be an instance of MimeBodyPart
+        assertThat(rootPart.getCount()).isEqualTo(1);
+        assertThat(rootPart.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
+        var bodyPart = (MimeBodyPart) rootPart.getBodyPart(0);
+        // our `bodyPart` should have a MimeMultiPart as content, our `contentPart`
+        assertThat(bodyPart.getContent())
+                .isNotNull()
+                .isInstanceOf(MimeMultipart.class);
+        var contentPart = (MimeMultipart) bodyPart.getContent();
+        // our `contentPart` should have a contentType starting by `multipart/related;` to be valid
+        assertThat(contentPart.getContentType()).startsWith("multipart/related;");
+        // our `contentPart` should have a contentType containing `boundary="..."` to be valid
+        assertThat(contentPart.getContentType()).containsPattern("boundary=\".*\"");
+        // our `contentPart` should contain one part, our `contentWrapperPart` that should be an instance of MimeBodyPart
+        // ... I know, email structures are cumbersome...
+        assertThat(contentPart.getCount()).isEqualTo(1);
+        assertThat(contentPart.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
+        var contentWrapperPart = (MimeBodyPart) contentPart.getBodyPart(0);
+        // our `contentWrapperPart` should have a MimeMultiPart as content, our `alternativeContentPart`
+        assertThat(contentWrapperPart.getContent())
+                .isNotNull()
+                .isInstanceOf(MimeMultipart.class);
+        var alternativeContentPart = (MimeMultipart) contentWrapperPart.getContent();
+        // our `alternativeContentPart` should have a contentType starting by `multipart/alternative;` to be valid
+        assertThat(alternativeContentPart.getContentType()).startsWith("multipart/alternative;");
+        // our `alternativeContentPart` should have a contentType containing `boundary="..."` to be valid
+        assertThat(rootPart.getContentType()).containsPattern("boundary=\".*\"");
+        // our `alternativeContentPart` should contain two parts
+        assertThat(alternativeContentPart.getCount()).isEqualTo(2);
+        // the first part of our `alternativeContentPart` should be our `textPlainPart`
+        var textPlainPart = alternativeContentPart.getBodyPart(0);
+        // our `textPlainPart` should have a dataHandler with contentType `text/plain; charset=UTF-8`
+        assertThat(textPlainPart.getDataHandler().getContentType()).isEqualTo("text/plain; charset=UTF-8");
+        // our `textPlainPart` should contain our text plain content
+        assertThat(textPlainPart.getContent()).isEqualTo(TEST_DATA.plainText());
+        // the second part of our `alternativeContentPart` should be our `htmlPart`
+        var htmlPart = alternativeContentPart.getBodyPart(1);
+        // our `htmlPart` should have a dataHandler with contentType `text/html;charset=UTF-8` as contentType
+        assertThat(htmlPart.getDataHandler().getContentType()).isEqualTo("text/html;charset=UTF-8");
+        // our `htmlPart` should contain our html content
+        assertThat(htmlPart.getContent()).isEqualTo(TEST_DATA.html());
+    }
+
+    private static EmailToSend testData() {
+        try {
+            var from = new InternetAddress("from@test.org");
+            var subject = "subject";
+            var plainText = "plain_text";
+            var htmlText = "html_text";
+            return new EmailToSend(from, subject, plainText, htmlText);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,13 @@ spring:
 gg:
   jte:
     developmentMode: true
+
+# required for email configuration
+app:
+  mail:
+    from:
+      address: "from@test.org"
+      name: "From Test"
+    reply-to:
+      address: "reply-to@test.org"
+      name: "ReplyTo Test"

--- a/src/test/resources/email/after_booking.html
+++ b/src/test/resources/email/after_booking.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="fr-CA">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confirmation d'inscription à un événement Devoxx4Kids Québec/Booking confirmation for a Devoxx4Kids Québec event</title>
+  <style>
+    body {
+      padding: 0.2em 1em;
+      font-family: 'Helvetica Neue', Helvetica, Arial, 'sans-serif';
+      box-sizing: border-box;
+      background-color: #777;
+      mso-line-height-rule: exactly;
+    }
+    h1 {
+      margin: 0;
+    }
+    table.layout {
+      border: none;
+      border-radius: 4px;
+      background-color: white;
+      width: 600px;
+      margin: auto;
+      border-collapse: collapse;
+    }
+    td.layout {
+      padding: 1em;
+      mso-line-height-rule: exactly;
+    }
+    span.italic-grey {
+      font-style: italic;
+      color: #777;
+    }
+    p.english-version {
+      font-style: italic;
+      color: #777;
+      display: inline-block;
+      margin: 2em 0 1em 0;
+    }
+    table.header {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      border-radius: 0;
+      margin: 0;
+    }
+    table.main-table {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border-radius: 0;
+      border: none;
+      margin: 0;
+      line-height: 1.8em;
+    }
+    table.footer {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      border-radius: 0;
+      margin: 0;
+      font-size: 0.8em;
+      color: #777;
+      width: 100%;
+    }
+    td.with-top-bottom-padding {
+      padding: 0.8em 0;
+    }
+    td.italic {
+      font-style: italic;
+      padding: 0;
+    }
+    td.footer-left {
+      font-style: italic;
+    }
+    td.footer-right {
+      text-align: right;
+    }
+    a.link-button {
+      font-size: 0.8em;
+      background-color: #f0690a;
+      text-decoration: none;
+      padding: 0.2em 0.8em;
+      color: white;
+      display: inline-block;
+      border-radius: 4px;
+      mso-padding-alt: 0;
+      text-underline-color: #f0690a;
+      border: 2px solid #f0690a;
+    }
+    a.link-button:hover {
+      background-color: white;
+      color: #f0690a;
+    }
+  </style>
+  <style>
+    td.participant {
+      padding: 0 0 0.8em 1em;
+    }
+    table.participant {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      margin: 0;
+      line-height: 1.6em;
+    }
+  </style>
+</head>
+<body>
+<table class="layout">
+  <tbody>
+    <tr>
+      <td class="layout">
+        <header>
+          <table class="header">
+            <tbody>
+            <tr>
+              <td>
+                <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2014/06/D4K_QUEBEC_1000px.png"
+                     alt="Devoxx4Kids Québec logo"
+                     width="560"
+                     style="width: 560px; margin: auto;">
+              </td>
+            </tr>
+            <tr>
+              <td><span class="italic-grey">Devoxx4Kids Québec</span></td>
+            </tr>
+            <tr>
+              <td style="padding: 1.8em 0;">
+                <h1>Inscription confirmée!</h1>
+              </td>
+            </tr>
+            <tr>
+              <td><span class="italic-grey">The English version will follow</span></td>
+            </tr>
+            </tbody>
+          </table>
+        </header>
+      </td>
+    </tr>
+    <tr>
+      <td class="layout">
+        <main>
+          <table class="main-table" lang="fr-CA" xml:lang="fr-CA">
+            <tbody>
+              <tr>
+                <td>Bonjour booker-firstName-é booker-lastName-ü,</td>
+              </tr>
+              <tr>
+                <td>Nous vous confirmons votre inscription pour l'événement</td>
+              </tr>
+              <tr>
+                <td class="with-top-bottom-padding"><strong>Test Event</strong></td>
+              </tr>
+              <tr>
+                <td>programmé le <time datetime="2025-04-15">15/04/2025</time>.</td>
+              </tr>
+              <tr>
+                <td class="with-top-bottom-padding">Lors de cet événement,</td>
+              </tr>
+              <tr>
+                <td class="participant">
+                  <table class="participant">
+                    <tbody>
+                      <tr>
+                        <td>part-firstName-é part-lastName-ü</td>
+                      </tr>
+                      <tr>
+                        <td>participera à l'activité:</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Test Activity</strong></td>
+                      </tr>
+                      <tr>
+                        <td>démarrant à <time datetime="2025-04-15T13:25:00">13:25 p.m.</time></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td class="participant">
+                  <table class="participant">
+                    <tbody>
+                      <tr>
+                        <td>second-firstName-é second-lastName-ü</td>
+                      </tr>
+                      <tr>
+                        <td>participera à l'activité:</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Test Activity</strong></td>
+                      </tr>
+                      <tr>
+                        <td>démarrant à <time datetime="2025-04-15T13:25:00">13:25 p.m.</time></td>
+                      </tr>
+                    </tbody>
+                  </table></td>
+              </tr>
+              <tr>
+                <td style="padding: 0;">Vous pouvez modifier votre inscription en utilisant le lien suivant:</td>
+              </tr>
+              <tr>
+                <td class="with-top-bottom-padding">
+                  <a href="https://placeholder_for_registration_link.test" class="link-button" target="_blank">
+                    <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+                    Gérer mon inscription
+                    <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td class="italic">On s'y voit bientôt!</td>
+              </tr>
+              <tr>
+                <td class="italic">L'équipe Devoxx4Kids Québec</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="english-version">English version:</p>
+          <table class="main-table" lang="en-CA" xml:lang="en-CA">
+            <tbody>
+              <tr>
+                <td>Hi booker-firstName-é booker-lastName-ü,</td>
+              </tr>
+              <tr>
+                <td>We confirm your activity booking for the event</td>
+              </tr>
+              <tr>
+                <td class="with-top-bottom-padding"><strong>Test Event</strong></td>
+              </tr>
+              <tr>
+                <td>scheduled on <time datetime="2025-04-15">04/15/2025</time>.</td>
+              </tr>
+              <tr>
+                <td class="with-top-bottom-padding">During this event,</td>
+              </tr>
+              <tr>
+                <td class="participant">
+                  <table class="participant">
+                    <tbody>
+                      <tr>
+                        <td>part-firstName-é part-lastName-ü</td>
+                      </tr>
+                      <tr>
+                        <td>will attend the activity:</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Test Activity</strong></td>
+                      </tr>
+                      <tr>
+                        <td>starting at <time datetime="2025-04-15T13:25:00">13:25 p.m.</time></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td class="participant">
+                  <table class="participant">
+                    <tbody>
+                      <tr>
+                        <td>second-firstName-é second-lastName-ü</td>
+                      </tr>
+                      <tr>
+                        <td>will attend the activity:</td>
+                      </tr>
+                      <tr>
+                        <td><strong>Test Activity</strong></td>
+                      </tr>
+                      <tr>
+                        <td>starting at <time datetime="2025-04-15T13:25:00">13:25 p.m.</time></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding: 0;">You can manage your booking using the following link:</td>
+              </tr>
+              <tr>
+                <td class="with-top-bottom-padding">
+                  <a href="https://placeholder_for_registration_link.test"
+                     class="link-button"
+                     target="_blank"
+                  >
+                    <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+                    Manage my booking
+                    <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td class="italic">See you soon there!</td>
+              </tr>
+              <tr>
+                <td class="italic">The Devoxx4Kids Québec team</td>
+              </tr>
+              <tr>
+                <td style="padding: 0; line-height: 1em;">&nbsp;</td>
+              </tr>
+            </tbody>
+          </table>
+        </main>
+      </td>
+    </tr>
+    <tr>
+    <td class="layout">
+      <footer>
+        <table class="footer">
+          <tbody>
+          <tr>
+            <td class="footer-left">© 2025 Québec – All rights reserved</td>
+            <td class="footer-right">
+              <table style="border: none; border-spacing: 0; border-collapse: collapse; margin: auto 0 auto auto; width: 100px;">
+                <tbody>
+                  <tr>
+                    <td>
+                      <a href="https://www.facebook.com/Devoxx4KidsQC/">
+                        <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2024/11/facebook-300x300.png"
+                             alt="Facebook logo"
+                             width="32"
+                             height="32"
+                             style="display: inline; width: 32px;">
+                      </a>
+                    </td>
+                    <td>
+                      <a href="https://www.linkedin.com/company/devoxx4kids-quebec/?viewAsMember=true">
+                        <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2024/11/linkedin-300x300.png"
+                             alt="LinkedIn logo"
+                             width="32"
+                             height="32"
+                             style="display: inline; width: 32px;">
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </footer>
+    </td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/test/resources/email/after_booking.txt
+++ b/src/test/resources/email/after_booking.txt
@@ -1,0 +1,38 @@
+Devoxx4Kids Québec, confirmation d'inscription à une activité (English version will follow):
+
+Bonjour booker-firstName-é booker-lastName-ü,
+Nous vous confirmons votre inscription pour l'événement Devoxx4kids Test Event le 15/04/2025.
+Lors de cet événement,
+
+  part-firstName-é part-lastName-ü
+  participera à l'activité:
+  Test Activity démarrant à 13:25 p.m.
+
+  second-firstName-é second-lastName-ü
+  participera à l'activité:
+  Test Activity démarrant à 13:25 p.m.
+
+Vous pouvez modifier votre inscription en utilisant le lien suivant: https://placeholder_for_registration_link.test
+
+On s'y voit bientôt!
+L'équipe Devoxx4Kids Québec.
+
+English version:
+Devoxx4Kids Québec, activity booking confirmation:
+
+Hi booker-firstName-é booker-lastName-ü,
+We confirm your activity booking for the Devoxx4Kids event Test Event on 04/15/2025.
+During this event,
+
+  part-firstName-é part-lastName-ü
+  will attend the activity:
+  Test Activity starting at 13:25 p.m.
+
+  second-firstName-é second-lastName-ü
+  will attend the activity:
+  Test Activity starting at 13:25 p.m.
+
+You can manage your booking using the following link: https://placeholder_for_registration_link.test
+
+See you soon there!
+The Devoxx4Kids Québec team.


### PR DESCRIPTION
Sorry for the big `PR`...

The code itself is pretty straight forward, but the testing and the local dev part needed a little more.

There's a `README.md` file in the `email` module as documentation, I don't want to copy it here.
If my rant about `Outlook` html rendering in this file does not respect the code of conduct of the project, let me know, I'll rephrase it... (but *why Micro$oft... why...?!?*).

As the logic for the link to manage the booking is not implemented, there's a placeholder that we will have to update later.

Correct a typo in `BookerRepository` because the `Id` type was `Long` instead of `String`.

The `html` rendering in `Outlook (classic)` is not perfect (there are some issues on the `padding` of the `button` for the management `link`, mostly due to spaces introduced by the templating engine around the `link` text). It might be considered as good enough.
It's also the reason why the `html` and `css` are ugly (layout with `table`, limited usage of `css selectors`, because `A B` is supported but not `A > B` 🤷...).

I'm not a specialist of `html` email, there might be better approaches for styling this email, feel free to contribute!

closes #12 
