### PR TITLE
chore: enable maven cache in GitHub action

### DIFF
--- a/.github/workflows/run-tests-and-deploy.yml
+++ b/.github/workflows/run-tests-and-deploy.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '21'
+          cache: 'maven'
       - name: Package and test with Maven
         run: ./mvnw clean package
       - name: Store reports


### PR DESCRIPTION
`setup-java@v4` offers a cache mechanism for `maven` dependencies to reuse them when not changed.
It will speed the build and remove the download from the build logs (as long as they don't change)