### PR TITLE
chore: avoid launching PgAdmin container in tests

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,9 @@ services:
       - 'POSTGRES_USER=myuser'
     ports:
       - '25432:5432'
+    profiles:
+      - ""
+      - "test"
 
 #  billetterie:
 ##    image: 'registry.fly.io/billetterie:deployment-01JRVD2DCA9K1BA7YE25RCSH6T'
@@ -23,3 +26,5 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: com@com.com
       PGADMIN_DEFAULT_PASSWORD: secret
+    profiles:
+      - ""

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,6 +6,8 @@ spring:
       file: compose.yaml
       skip:
         in-tests: false
+      profiles:
+        active: "test"
   # required for model creation during tests
   jpa:
     hibernate:


### PR DESCRIPTION
Use `docker compose` profiles and their integration in `SpringBoot` to drive conditional startup of the `PgAdmin` container.

This is used to avoid launching this container during our tests, in order to speed them up and save some resources.

`docker compose up` will still launch the `PgAdmin` container, as launching the `app` from the command line via
```shell
./mvnw spring-boot:run
```