### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      spring-boot:
+        patterns:
+         - "org.springframework.boot*"
+      third-parties:
+        exclude-patterns:
+          - "org.springframework.boot*"


### PR DESCRIPTION
Simple `Dependabot` config.
Tracks:
- `GitHub Actions`: weekly in a unique group
- `maven` dependencies: weekly, split `springboot` and others in two groups, in order to have only two `PR` max