### PR TITLE
chore: make logs quiet during tests and ensure @DataJpaTest use Pg container

### DIFF
--- a/src/test/java/org/montrealjug/billetterie/repository/ActivityParticipantRegistrationTest.java
+++ b/src/test/java/org/montrealjug/billetterie/repository/ActivityParticipantRegistrationTest.java
@@ -13,13 +13,11 @@ import org.montrealjug.billetterie.entity.Booker;
 import org.montrealjug.billetterie.entity.Event;
 import org.montrealjug.billetterie.entity.Participant;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-/**
- * @author OonihiloO
- * Contributed via https://github.com/montrealjug/billetterie/pull/21
- */
-@DataJpaTest
+@DataJpaTest(showSql = false)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class ActivityParticipantRegistrationTest {
 
     @Autowired EventRepository eventRepository;

--- a/src/test/java/org/montrealjug/billetterie/repository/ActivityRepositoryTest.java
+++ b/src/test/java/org/montrealjug/billetterie/repository/ActivityRepositoryTest.java
@@ -12,9 +12,11 @@ import org.montrealjug.billetterie.entity.Booker;
 import org.montrealjug.billetterie.entity.Event;
 import org.montrealjug.billetterie.entity.Participant;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class ActivityRepositoryTest {
 
     @Autowired EventRepository eventRepository;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,6 +13,8 @@ spring:
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  main:
+    banner-mode: off
 
 # required to have the templates compiled
 gg:
@@ -28,3 +30,12 @@ app:
     reply-to:
       address: "reply-to@test.org"
       name: "ReplyTo Test"
+# quiet mode for logs during tests
+logging:
+  level:
+    root: error # just log errors for root
+    org:
+      montrealjug:
+        billetterie:
+          email:
+            EmailService: off # deactivate logs for EmailService to avoid long useless stacks


### PR DESCRIPTION
A small `PR` to:
- make the log quiet during tests (banner off and no logs by default)
- ensure the `@DataJpaTest` use the `Pg` from the container

Having logs quiet will make our logs more readable while preserving any error

The addition of `
@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)` ensures that these tests are run against the `Pg` container automatically started by the integration with `docker compose`

The result for the logs can be seen in the workflow logs