### PR TITLE
feat: add a first step with the email only in the registration process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
 			<version>${jsoup.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/montrealjug/billetterie/email/EmailModel.java
+++ b/src/main/java/org/montrealjug/billetterie/email/EmailModel.java
@@ -35,7 +35,8 @@ public class EmailModel {
 
     public enum EmailType {
         AFTER_BOOKING,
-        AFTER_REGISTRATION;
+        AFTER_REGISTRATION,
+        RETURNING_BOOKER;
 
         public String subjectKey() {
             return this.name().toLowerCase();
@@ -88,6 +89,10 @@ public class EmailModel {
             return new AfterRegistrationEmail(booker, baseUrl);
         }
 
+        static Email returningBooker(Booker booker, String baseUrl) {
+            return new ReturningBookingEmail(booker, baseUrl);
+        }
+
         private static InternetAddress fromBooker(Booker booker) {
             try {
                 return new InternetAddress(
@@ -131,6 +136,22 @@ public class EmailModel {
         @Override
         public EmailType type() {
             return EmailType.AFTER_REGISTRATION;
+        }
+
+        @Override
+        public InternetAddress to() {
+            return Email.fromBooker(booker);
+        }
+
+        public String registrationLink() {
+            return baseUrl + "/bookings/" + booker.getEmailSignature();
+        }
+    }
+
+    public record ReturningBookingEmail(Booker booker, String baseUrl) implements Email {
+        @Override
+        public EmailType type() {
+            return EmailType.RETURNING_BOOKER;
         }
 
         @Override

--- a/src/main/java/org/montrealjug/billetterie/repository/EventRepository.java
+++ b/src/main/java/org/montrealjug/billetterie/repository/EventRepository.java
@@ -3,9 +3,12 @@ package org.montrealjug.billetterie.repository;
 
 import java.util.Optional;
 import org.montrealjug.billetterie.entity.Event;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.CrudRepository;
 
 public interface EventRepository extends CrudRepository<Event, Long> {
 
+    // Eager fetch activities, as we will always access them
+    @EntityGraph(attributePaths = {"activities"})
     Optional<Event> findByActiveIsTrue();
 }

--- a/src/main/jte/email/returning_booker-html.jte
+++ b/src/main/jte/email/returning_booker-html.jte
@@ -1,0 +1,88 @@
+@import org.montrealjug.billetterie.email.EmailModel.ReturningBookingEmail
+
+@param ReturningBookingEmail context
+!{var title = "Dernière étape avant de réserver une activité avec Devoxx4Kids Québec/Last step before booking an activity with Devoxx4Kids Québec";}
+!{var h1 = "Vous y êtes presque ! / You're almost there!";}
+@template.layouts.email_html_layout(
+title = title,
+h1 = h1,
+mainContent = @`
+  <table class="main-table" lang="fr-CA" xml:lang="fr-CA">
+    <tbody>
+    <tr>
+      <td>
+        Bonjour ${context.booker().getFirstName()} ${context.booker().getLastName()},
+      </td>
+    </tr>
+    <tr>
+      <td>Merci de votre intérêt pour notre prochain événement !</td>
+    </tr>
+    <tr>
+      <td>Si c'est bien vous qui souhaitez réserver une activité, merci d'utiliser le lien suivant :</td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        <a href="${context.registrationLink()}"
+           class="link-button"
+           target="_blank"
+        >
+          @raw
+          <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+          Réserver une activité
+          <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+          @endraw
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td class="italic">Après avoir cliqué sur ce lien, vous pourrez inscrire votre(vos) enfant(s) aux différentes activités du prochain événement</td>
+    </tr>
+    <tr>
+      <td class="italic">L'équipe Devoxx4Kids Québec</td>
+    </tr>
+    </tbody>
+  </table>
+  <p class="english-version">English version:</p>
+  <table class="main-table" lang="en-CA" xml:lang="en-CA">
+    <tbody>
+    <tr>
+      <td>
+        Hi ${context.booker().getFirstName()} ${context.booker().getLastName()},
+      </td>
+    </tr>
+    <tr>
+      <td>Thanks for your interest for our next event!</td>
+    </tr>
+    <tr>
+      <td>
+        If it was you who wanted to book an activity, then please use the following link:
+      </td>
+    </tr>
+    <tr>
+      <td class="with-top-bottom-padding">
+        <a href="${context.registrationLink()}"
+           class="link-button"
+           target="_blank"
+        >
+          @raw
+          <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+          Book an activity
+          <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+          @endraw
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td class="italic">After you click on the link, you'll be able to book activities for your child(ren)</td>
+    </tr>
+    <tr>
+      <td class="italic">The Devoxx4Kids Québec team</td>
+    </tr>
+    <!-- ghost line to avoid a strange border in Outlook classic 🤷-->
+    <tr>
+      <td style="padding: 0; line-height: 1em;">&nbsp;</td>
+    </tr>
+    </tbody>
+  </table>
+`)
+

--- a/src/main/jte/email/returning_booker-plain.jte
+++ b/src/main/jte/email/returning_booker-plain.jte
@@ -1,0 +1,21 @@
+@import org.montrealjug.billetterie.email.EmailModel.ReturningBookingEmail
+
+@param ReturningBookingEmail context
+Devoxx4Kids Québec, dernière étape avant de réserver une activité (English version will follow):
+
+Bonjour ${context.booker().getFirstName()} ${context.booker().getLastName()},
+Merci de votre intérêt pour notre prochain événement !
+Si c'est bien vous qui souhaitez réserver une activité, merci d'utiliser le lien suivant : ${context.registrationLink()}
+
+Après avoir cliqué sur ce lien, vous pourrez inscrire votre(vos) enfant(s) aux différentes activités du prochain événement.
+L'équipe Devoxx4Kids Québec.
+
+English version:
+Devoxx4Kids Québec, last step before booking an activity:
+
+Hi ${context.booker().getFirstName()} ${context.booker().getLastName()},
+Thanks for your interest for our next event!
+If it was you who wanted to book an activity, then please use the following link: ${context.registrationLink()}
+
+After you click on the link, you'll be able to book activities for your child(ren).
+The Devoxx4Kids Québec team.

--- a/src/main/jte/index.jte
+++ b/src/main/jte/index.jte
@@ -18,7 +18,7 @@
 
 <div class="min-h-screen flex flex-col items-center justify-center">
     @if(error != null)
-        <div class="bg-red-500 text-white p-4 mb-4 rounded-md w-full max-w-4xl">
+        <div id="main-error-message" class="bg-red-500 text-white p-4 mb-4 rounded-md w-full max-w-4xl">
             ${error}
         </div>
     @endif
@@ -83,8 +83,11 @@
                         class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300">
                     Register
                 </button>
-                <div id="success-message" class="mt-4 p-4 bg-green-100 text-green-700 rounded-md hidden">
+                <div id="success-registration-message" class="mt-4 p-4 bg-green-100 text-green-700 rounded-md hidden">
                     You have successfully registered your email address, please check your inbox and click on the verification link to register your kids to the activities
+                </div>
+                <div id="success-returning-message" class="mt-4 p-4 bg-green-100 text-green-700 rounded-md hidden">
+                    We've sent you an email to finish the registration, please check your inbox and click on the registration link to register your kids to the activities
                 </div>
             </div>
 
@@ -97,101 +100,36 @@
     </div>
 
     <script>
-
         function displayRegistrationModal() {
             // Create the modal elements
             const modal = document.createElement("div");
             modal.id = "registration-modal";
             modal.className = "fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50";
-
             modal.innerHTML = `
-        <div class="bg-white rounded-lg shadow-md p-6 w-96">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">Register</h2>
-            <form id="registration-form" class="space-y-4">
-                <div>
-                    <label for="first-name" class="block text-gray-700">First Name</label>
-                    <input type="text" id="first-name" name="firstName" class="border border-gray-300 rounded px-3 py-2 w-full" required>
-                </div>
-                <div>
-                    <label for="last-name" class="block text-gray-700">Last Name</label>
-                    <input type="text" id="last-name" name="lastName" class="border border-gray-300 rounded px-3 py-2 w-full" required>
-                </div>
-                <div>
-                    <label for="email" class="block text-gray-700">Email</label>
-                    <input type="email" id="email" name="email" class="border border-gray-300 rounded px-3 py-2 w-full" required>
-                </div>
-                <div>
-                    <label for="confirm-email" class="block text-gray-700">Confirm Email</label>
-                    <input type="email" id="confirm-email" name="confirmEmail" class="border border-gray-300 rounded px-3 py-2 w-full" required>
-                </div>
-                <div id="error-message" class="text-red-500 text-sm hidden"></div>
-                <div class="flex justify-end gap-2">
-                    <button type="button" onclick="closeModal()" class="bg-gray-300 text-gray-700 px-3 py-1 rounded hover:bg-gray-400 focus:outline-none focus:ring">Cancel</button>
-                    <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300">Submit</button>
-                </div>
-            </form>
-        </div>
-    `;
-
+            <div class="bg-white rounded-lg shadow-md p-6 w-96">
+                <h2 class="text-lg font-semibold text-gray-800 mb-4">Register</h2>
+                <p id="first-registration-message" class="text-gray-800 text-sm mb-4 hidden">
+                  You're registering for the first time, please let us know a little more about yourself
+                </p>
+                <form id="registration-form" class="space-y-4">
+                    <fieldset>
+                        <div>
+                            <label for="email" class="block text-gray-700">Email</label>
+                            <input type="email" id="email" name="email" class="border border-gray-300 rounded px-3 py-2 w-full" required>
+                        </div>
+                    </fieldset>
+                    <p id="error-message" class="text-red-500 text-sm hidden"></p>
+                    <div class="flex justify-end gap-2">
+                        <button type="button" onclick="closeModal()" class="bg-gray-300 text-gray-700 px-3 py-1 rounded hover:bg-gray-400 focus:outline-none focus:ring">Cancel</button>
+                        <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300">Submit</button>
+                    </div>
+                </form>
+            </div>
+            `;
+            // add the modal in DOM
             document.body.appendChild(modal);
-
-            const form = document.getElementById("registration-form");
-            const errorMessage = document.getElementById("error-message");
-
-            form.addEventListener("submit", async (e) => {
-                e.preventDefault();
-
-                // Gather form data
-                const firstName = form.firstName.value.trim();
-                const lastName = form.lastName.value.trim();
-                const email = form.email.value.trim();
-                const confirmEmail = form.confirmEmail.value.trim();
-
-                // Validate inputs
-                if (!firstName || !lastName || !email || !confirmEmail) {
-                    errorMessage.textContent = "Please fill in all fields.";
-                    errorMessage.classList.remove("hidden");
-                    return;
-                }
-
-                if (email !== confirmEmail) {
-                    errorMessage.textContent = "Emails do not match.";
-                    errorMessage.classList.remove("hidden");
-                    return;
-                }
-
-                errorMessage.classList.add("hidden");
-
-                // Send HTTP POST request
-                try {
-                    const response = await fetch("/registerBooker", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({firstName, lastName, email}),
-                    });
-
-                    if (response.ok) {
-                        closeModal();
-                        // Show success message
-                        const successMessage = document.getElementById("success-message");
-                        successMessage.classList.remove("hidden");
-                        // Disable register button
-                        const registerButton = document.getElementById("register-button");
-                        registerButton.disabled = true;
-                        registerButton.classList.add("opacity-50", "cursor-not-allowed");
-                    } else {
-                        const errorData = await response.json();
-                        errorMessage.textContent = errorData.message || "Registration failed.";
-                        errorMessage.classList.remove("hidden");
-                    }
-                } catch (error) {
-                    console.error("Error during registration:", error);
-                    errorMessage.textContent = "An error occurred. Please try again.";
-                    errorMessage.classList.remove("hidden");
-                }
-            });
+            const form = modal.querySelector("#registration-form");
+            form.addEventListener("submit", onRegistrationFormSubmit);
         }
 
         function closeModal() {
@@ -200,10 +138,133 @@
                 modal.remove();
             }
         }
+
+        function displayFullRegistrationForm(form, email) {
+            const fieldSet = form.querySelector("fieldset");
+            fieldSet.innerHTML = `
+            <div>
+                <label for="first-name" class="block text-gray-700">First Name</label>
+                <input type="text" id="first-name" name="firstName" class="border border-gray-300 rounded px-3 py-2 w-full" required>
+            </div>
+            <div>
+                <label for="last-name" class="block text-gray-700">Last Name</label>
+                <input type="text" id="last-name" name="lastName" class="border border-gray-300 rounded px-3 py-2 w-full" required>
+            </div>
+            <div>
+                <label for="email" class="block text-gray-700">Email</label>
+                <input type="email" id="email" name="email" class="border border-gray-300 rounded px-3 py-2 w-full" required>
+            </div>
+            <div>
+                <label for="confirm-email" class="block text-gray-700">Confirm Email</label>
+                <input type="email" id="confirm-email" name="confirmEmail" class="border border-gray-300 rounded px-3 py-2 w-full" required>
+            </div>
+            `;
+            form.email.value = email;
+            form.parentElement.querySelector("#first-registration-message").classList.remove("hidden");
+        }
+
+        async function onRegistrationFormSubmit(event) {
+            event.preventDefault();
+            const form = event.target;
+            const errorMessage = form.querySelector("#error-message");
+            errorMessage.classList.add("hidden");
+            const isFullRegistration = form.querySelector("#confirm-email") !== null;
+            if (isFullRegistration) {
+                await registerNewBooker(form, errorMessage);
+            } else {
+                await checkReturningBooker(form, errorMessage);
+            }
+        }
+
+        async function checkReturningBooker(form, errorMessage) {
+            const email = form.email.value.trim();
+            if (!email) {
+                errorMessage.textContent = "Please provide an email address.";
+                errorMessage.classList.remove("hidden");
+                return;
+            }
+            try {
+                const response = await fetch("/check-returning-booker", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ email }),
+                });
+                switch (response.status) {
+                    case 204:
+                        onRegistrationCompleted("returning");
+                        break;
+                    case 404:
+                        displayFullRegistrationForm(form, email);
+                        break;
+                    default:
+                        console.error("unexpected status code: " + response.status);
+                        errorMessage.textContent = "An error occurred. Please try again.";
+                        errorMessage.classList.remove("hidden");
+                        break;
+                }
+            } catch (error) {
+                console.error("Error during registration:", error);
+                errorMessage.textContent = "An error occurred. Please try again.";
+                errorMessage.classList.remove("hidden");
+            }
+        }
+
+        async function registerNewBooker(form, errorMessage) {
+            // Gather form data
+            const firstName = form.firstName.value.trim();
+            const lastName = form.lastName.value.trim();
+            const email = form.email.value.trim();
+            const confirmEmail = form.confirmEmail.value.trim();
+            // Validate inputs
+            if (!firstName || !lastName || !email || !confirmEmail) {
+                errorMessage.textContent = "Please fill in all fields.";
+                errorMessage.classList.remove("hidden");
+                return;
+            }
+            if (email !== confirmEmail) {
+                errorMessage.textContent = "Emails do not match.";
+                errorMessage.classList.remove("hidden");
+                return;
+            }
+            // Send HTTP POST request
+            try {
+                const response = await fetch("/register-booker", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ firstName, lastName, email }),
+                });
+                if (response.ok) {
+                    onRegistrationCompleted("registration");
+                } else {
+                    const errorData = await response.json();
+                    errorMessage.textContent = errorData.message || "Registration failed.";
+                    errorMessage.classList.remove("hidden");
+                }
+            } catch (error) {
+                console.error("Error during registration:", error);
+                errorMessage.textContent = "An error occurred. Please try again.";
+                errorMessage.classList.remove("hidden");
+            }
+        }
+
+        function onRegistrationCompleted(registrationType) {
+            closeModal();
+            @raw
+            const successMessageId = `success-${registrationType}-message`;
+            @endraw
+            // Show success message
+            const successMessage = document.getElementById(successMessageId);
+            successMessage.classList.remove("hidden");
+            // Disable register button
+            const registerButton = document.getElementById("register-button");
+            registerButton.disabled = true;
+            registerButton.classList.add("opacity-50", "cursor-not-allowed");
+        }
     </script>
-
 </div>
-
-
 </body>
 </html>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,2 +1,3 @@
 after_booking=Merci d'avoir réservé une activité avec Devoxx4Kids Québec! / Thanks for booking an activity with Devoxx4Kids Québec!
 after_registration=Merci d'avoir enregistré votre adresse courriel avec Devoxx4Kids Québec! / Thanks for registering your email with Devoxx4Kids Québec!
+returning_booker=Dernière étape avant de réserver une activité avec Devoxx4Kids Québec! / Last step before booking an activity with Devoxx4Kids Québec!

--- a/src/test/java/org/montrealjug/billetterie/email/EmailWriterTest.java
+++ b/src/test/java/org/montrealjug/billetterie/email/EmailWriterTest.java
@@ -58,7 +58,7 @@ class EmailWriterTest {
     }
 
     static Stream<Arguments> emails() {
-        return Stream.of(Arguments.of(forAfterBooking()));
+        return Stream.of(Arguments.of(forAfterBooking()), Arguments.of(forReturningBooker()));
     }
 
     static Email forAfterBooking() {
@@ -99,5 +99,15 @@ class EmailWriterTest {
                 .setParticipantId(secondParticipant.getId());
         var participants = Set.of(firstActivityParticipant, secondActivityParticipant);
         return Email.afterBooking(booker, event, participants);
+    }
+
+    static Email forReturningBooker() {
+        var booker = new Booker();
+        booker.setEmail("email@test.org");
+        booker.setFirstName("booker-firstName");
+        booker.setLastName("booker-lastName");
+        booker.setEmailSignature("signature");
+        var baseUrl = "base_url";
+        return Email.returningBooker(booker, baseUrl);
     }
 }

--- a/src/test/java/org/montrealjug/billetterie/ui/RegistrationControllerTest.java
+++ b/src/test/java/org/montrealjug/billetterie/ui/RegistrationControllerTest.java
@@ -1,22 +1,89 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.montrealjug.billetterie.ui;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.xml.element.NodeChildren;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
+import org.montrealjug.billetterie.email.EmailModel.Email;
+import org.montrealjug.billetterie.email.EmailModel.EmailType;
+import org.montrealjug.billetterie.email.EmailService;
+import org.montrealjug.billetterie.entity.Activity;
+import org.montrealjug.billetterie.entity.Booker;
+import org.montrealjug.billetterie.entity.Event;
 import org.montrealjug.billetterie.entity.Participant;
+import org.montrealjug.billetterie.repository.BookerRepository;
+import org.montrealjug.billetterie.repository.EventRepository;
+import org.montrealjug.billetterie.service.SignatureService;
+import org.montrealjug.billetterie.ui.RegistrationController.BookerCheck;
+import org.montrealjug.billetterie.ui.RegistrationController.ParticipantSubmission;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
+@SpringBootTest(webEnvironment = RANDOM_PORT)
 class RegistrationControllerTest {
+
+    @LocalServerPort private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @AfterEach
+    void tearDown() {
+        // dirty trick to make the test idempotent without
+        // dropping all data from the container to not impact local dev.
+        // we can't use spring's @Transactional because the transaction
+        // won't be committed and the data won't be available in the web layer
+        // that shouldn't be done, but it will ease dev life
+        bookerRepository.deleteAllById(CREATED_BOOKER_IDS);
+        eventRepository.deleteAllById(CREATED_EVENT_IDS);
+        CREATED_BOOKER_IDS.clear();
+        CREATED_EVENT_IDS.clear();
+    }
+
+    static final Set<String> CREATED_BOOKER_IDS = new HashSet<>();
+    static final Set<Long> CREATED_EVENT_IDS = new HashSet<>();
+
+    @Autowired BookerRepository bookerRepository;
+
+    @Autowired EventRepository eventRepository;
+
+    @MockitoBean SignatureService signatureService;
+
+    @MockitoSpyBean EmailService emailService;
+
+    @Captor ArgumentCaptor<Email> emailCaptor;
 
     @Test
     void retrieveBaseUrlTest() {
-        // Create the controller
-        RegistrationController controller =
-                new RegistrationController(null, null, null, null, null, null);
-
         // Create a mock HttpServletRequest
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 
@@ -27,7 +94,7 @@ class RegistrationControllerTest {
         when(request.getContextPath()).thenReturn("");
 
         // Call the method and verify the result
-        String baseUrl = controller.retrieveBaseUrl(request);
+        String baseUrl = RegistrationController.retrieveBaseUrl(request);
         assertEquals("http://localhost:8080", baseUrl);
 
         // Test with a different URL and context path
@@ -36,16 +103,12 @@ class RegistrationControllerTest {
         when(request.getRequestURI()).thenReturn("/some/path");
         when(request.getContextPath()).thenReturn("/app");
 
-        baseUrl = controller.retrieveBaseUrl(request);
+        baseUrl = RegistrationController.retrieveBaseUrl(request);
         assertEquals("https://example.com/app", baseUrl);
     }
 
     @Test
     public void isSameParticipantTest() {
-        // Create the controller the same way as in retrieveBaseUrlTest
-        RegistrationController controller =
-                new RegistrationController(null, null, null, null, null, null);
-
         // Create a Participant
         Participant participant = new org.montrealjug.billetterie.entity.Participant();
         participant.setFirstName("John");
@@ -55,31 +118,298 @@ class RegistrationControllerTest {
         // Test with matching submission
         ParticipantSubmission matchingSubmission =
                 new ParticipantSubmission("John", "Doe", 1990, 1L, "signature");
-        boolean result = controller.isSameParticipant(participant, matchingSubmission);
+        boolean result = RegistrationController.isSameParticipant(participant, matchingSubmission);
         assertTrue(result, "Should return true for matching participant");
 
         // Test with different first name
         ParticipantSubmission differentFirstNameSubmission =
                 new ParticipantSubmission("Jane", "Doe", 1990, 1L, "signature");
-        result = controller.isSameParticipant(participant, differentFirstNameSubmission);
+        result =
+                RegistrationController.isSameParticipant(participant, differentFirstNameSubmission);
         assertFalse(result, "Should return false for different first name");
 
         // Test with different last name
         ParticipantSubmission differentLastNameSubmission =
                 new ParticipantSubmission("John", "Smith", 1990, 1L, "signature");
-        result = controller.isSameParticipant(participant, differentLastNameSubmission);
+        result = RegistrationController.isSameParticipant(participant, differentLastNameSubmission);
         assertFalse(result, "Should return false for different last name");
 
         // Test with different year of birth
         ParticipantSubmission differentYearSubmission =
                 new ParticipantSubmission("John", "Doe", 1991, 1L, "signature");
-        result = controller.isSameParticipant(participant, differentYearSubmission);
+        result = RegistrationController.isSameParticipant(participant, differentYearSubmission);
         assertFalse(result, "Should return false for different year of birth");
 
         // Test case insensitivity
         ParticipantSubmission caseInsensitiveSubmission =
                 new ParticipantSubmission("JOHN", "DOE", 1990, 1L, "signature");
-        result = controller.isSameParticipant(participant, caseInsensitiveSubmission);
+        result = RegistrationController.isSameParticipant(participant, caseInsensitiveSubmission);
         assertTrue(result, "Should return true for case-insensitive match");
+    }
+
+    @Test
+    void checkReturningBooker_should_return_404_if_no_booker_found_without_sending_any_email() {
+        var email = "not-known-email@test.org";
+        var bookerCheck = new BookerCheck(email);
+
+        given().contentType(ContentType.JSON)
+                .body(bookerCheck)
+                .when()
+                .post("/check-returning-booker")
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+
+        verifyNoInteractions(emailService);
+    }
+
+    @Test
+    void
+            checkReturningBooker_should_return_204_sending_RETURNING_BOOKER_email_if_booker_known_and_confirmed() {
+        var email = "returning-booker@test.org";
+        createBooker(email, true);
+        var bookerCheck = new BookerCheck(email);
+
+        given().contentType(ContentType.JSON)
+                .body(bookerCheck)
+                .when()
+                .post("/check-returning-booker")
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        verify(emailService).sendEmail(emailCaptor.capture());
+        assertThat(emailCaptor.getValue().type()).isSameAs(EmailType.RETURNING_BOOKER);
+    }
+
+    @Test
+    void
+            checkReturningBooker_should_return_204_sending_AFTER_REGISTRATION_email_if_booker_known_and_not_confirmed() {
+        var email = "not-verified-booker@test.org";
+        createBooker(email, false);
+        var bookerCheck = new BookerCheck(email);
+
+        given().contentType(ContentType.JSON)
+                .body(bookerCheck)
+                .when()
+                .post("/check-returning-booker")
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        verify(emailService).sendEmail(emailCaptor.capture());
+        assertThat(emailCaptor.getValue().type()).isSameAs(EmailType.AFTER_REGISTRATION);
+    }
+
+    @Test
+    void
+            registerBooker_should_return_a_201_after_saving_booker_in_db_and_sending_AFTER_REGISTRATION_email()
+                    throws Exception {
+        var email = "registration-booker@test.org";
+        when(signatureService.signAndTrim(email)).thenReturn(SIGNATURE);
+        var booker = new PresentationBooker("New", "Booker", email);
+        CREATED_BOOKER_IDS.add(email);
+
+        given().contentType(ContentType.JSON)
+                .body(booker)
+                .when()
+                .post("/register-booker")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        var savedBooker = bookerRepository.findById(email);
+        assertThat(savedBooker)
+                .hasValueSatisfying(
+                        b -> {
+                            assertThat(b.getFirstName()).isEqualTo(booker.firstName());
+                            assertThat(b.getLastName()).isEqualTo(booker.lastName());
+                            assertThat(b.getEmail()).isEqualTo(booker.email());
+                            assertThat(b.getEmailSignature()).isEqualTo(SIGNATURE);
+                            assertThat(b.getValidationTime()).isNull();
+                        });
+        verify(emailService).sendEmail(emailCaptor.capture());
+        assertThat(emailCaptor.getValue().type()).isSameAs(EmailType.AFTER_REGISTRATION);
+    }
+
+    @Test
+    void registerBooker_should_return_a_409_without_sending_email_if_email_is_known() {
+        var email = "already-registered@test.org";
+        createBooker(email, false);
+        var booker = new PresentationBooker("Other First Name", "Other Last Name", email);
+
+        given().contentType(ContentType.JSON)
+                .body(booker)
+                .when()
+                .post("/register-booker")
+                .then()
+                .statusCode(HttpStatus.CONFLICT.value());
+        verifyNoInteractions(emailService, signatureService);
+    }
+
+    @Test
+    void startBooking_should_display_bookers_activity_if_Booker_exists_and_an_Event_is_active() {
+        // create a Booker
+        var email = "start-booking@test.org";
+        createBooker(email, false);
+        // get the active Event (creates it if needed)
+        var event = getOrCreateActiveEvent();
+        // keep track of time
+        var beforeCall = Instant.now();
+
+        var htmlPath =
+                given().pathParam("signature", SIGNATURE)
+                        .when()
+                        .get("/bookings/{signature}")
+                        .then()
+                        .statusCode(HttpStatus.OK.value())
+                        .contentType(ContentType.HTML)
+                        .extract()
+                        .htmlPath();
+
+        // check the title to ensure we are in the html generated by the `booker-activities.jte`
+        // template
+        assertThat((String) htmlPath.get("html.head.title")).isEqualTo("Event Activities");
+        // check that booker validationTime has been updated
+        var validatedBooker =
+                bookerRepository
+                        .findById(email)
+                        .orElseThrow(() -> new IllegalStateException("Booker not found"));
+        assertThat(validatedBooker.getValidationTime()).isBetween(beforeCall, Instant.now());
+    }
+
+    @Test
+    void startBooking_should_not_update_validationTime_if_already_set() {
+        // create an already validated Booker
+        var email = "start-bookingr@test.org";
+        var booker = createBooker(email, true);
+        // get the active Event (creates it if needed)
+        getOrCreateActiveEvent();
+
+        var htmlPath =
+                given().pathParam("signature", SIGNATURE)
+                        .when()
+                        .get("/bookings/{signature}")
+                        .then()
+                        .statusCode(HttpStatus.OK.value())
+                        .contentType(ContentType.HTML)
+                        .extract()
+                        .htmlPath();
+
+        // check the title to ensure we are in the html generated by the `booker-activities.jte`
+        // template
+        assertThat((String) htmlPath.get("html.head.title")).isEqualTo("Event Activities");
+        // check that booker validationTime has been updated
+        var validatedBooker =
+                bookerRepository
+                        .findById(email)
+                        .orElseThrow(() -> new IllegalStateException("Booker not found"));
+        // compare with millis, because we lose precision in the DB
+        assertThat(validatedBooker.getValidationTime().truncatedTo(ChronoUnit.MILLIS))
+                .isEqualTo(booker.getValidationTime().truncatedTo(ChronoUnit.MILLIS));
+    }
+
+    @Test
+    void startBooking_should_display_index_if_no_Booker_found_while_displaying_an_error_message() {
+        // create an already validated Booker
+        var email = "start-booking@test.org";
+        createBooker(email, true);
+        // get the active Event (creates it if needed)
+        getOrCreateActiveEvent();
+
+        var htmlPath =
+                given().pathParam("signature", "not-known-signature")
+                        .when()
+                        .get("/bookings/{signature}")
+                        .then()
+                        .statusCode(HttpStatus.OK.value())
+                        .contentType(ContentType.HTML)
+                        .extract()
+                        .htmlPath();
+
+        // check the title to ensure we are in the html generated by the `index.jte`
+        // template
+        assertThat((String) htmlPath.get("html.head.title")).isEqualTo("Event List");
+        // check that the error msg is present
+        // not ideal because coupled to the `html` structure but will do the job for now
+        var errorMsgNode = ((NodeChildren) htmlPath.get("html.body.div.div")).get(0);
+        assertThat(errorMsgNode.getAttribute("id")).isEqualTo("main-error-message");
+    }
+
+    @Test
+    void
+            startBooking_should_display_index_without_error_msg_if_Booker_found_but_no_Event_is_active() {
+        // create an already validated Booker
+        var email = "start-booking@test.org";
+        createBooker(email, true);
+        // get the active Event (creates it if needed)
+        var event = getOrCreateActiveEvent();
+        // a little dirty, but easy way to stay idempotent while testing without an active Event
+        try {
+            event.setActive(false);
+            eventRepository.save(event);
+            var htmlPath =
+                    given().pathParam("signature", SIGNATURE)
+                            .when()
+                            .get("/bookings/{signature}")
+                            .then()
+                            .statusCode(HttpStatus.OK.value())
+                            .contentType(ContentType.HTML)
+                            .extract()
+                            .htmlPath();
+
+            // check the title to ensure we are in the html generated by the `index.jte`
+            // template
+            assertThat((String) htmlPath.get("html.head.title")).isEqualTo("Event List");
+            // check that the error msg is not present
+            // not ideal because coupled to the `html` structure but will do the job for now
+            var errorMsgNode = ((NodeChildren) htmlPath.get("html.body.div.div")).get(0);
+            assertThat(errorMsgNode.getAttribute("id")).isNotEqualTo("main-error-message");
+        } finally {
+            // restore the active state of the Event
+            event.setActive(true);
+            eventRepository.save(event);
+        }
+    }
+
+    private Event getOrCreateActiveEvent() {
+        var activeEvent =
+                eventRepository
+                        .findByActiveIsTrue()
+                        .orElseGet(
+                                () -> {
+                                    var event = new Event();
+                                    event.setTitle("Test Event");
+                                    event.setDescription("Test Description");
+                                    event.setActive(true);
+                                    event.setDate(LocalDate.now());
+                                    event = eventRepository.save(event);
+                                    CREATED_EVENT_IDS.add(event.getId());
+                                    return event;
+                                });
+
+        if (activeEvent.getActivities().isEmpty()) {
+            // add an Activity to the active Event
+            var activity = new Activity();
+            activity.setTitle("Test Activity");
+            activity.setEvent(activeEvent);
+            activity.setStartTime(LocalDateTime.now().plusMinutes(1L));
+            activity.setMaxParticipants(12);
+            activity.setMaxWaitingQueue(123);
+            activeEvent.getActivities().add(activity);
+            activeEvent = eventRepository.save(activeEvent);
+        }
+        return activeEvent;
+    }
+
+    static final String SIGNATURE = "signature";
+
+    Booker createBooker(String email, boolean verified) {
+        var booker = new Booker();
+        booker.setFirstName("For test");
+        booker.setLastName("Booker");
+        booker.setEmail(email);
+        booker.setEmailSignature(SIGNATURE);
+        if (verified) {
+            booker.setValidationTime(Instant.now());
+        }
+        CREATED_BOOKER_IDS.add(email);
+        return bookerRepository.save(booker);
     }
 }

--- a/src/test/resources/email/returning_booker.html
+++ b/src/test/resources/email/returning_booker.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="fr-CA">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dernière étape avant de réserver une activité avec Devoxx4Kids Québec/Last step before booking an activity with Devoxx4Kids Québec</title>
+  <style>
+    body {
+      padding: 0.2em 1em;
+      font-family: 'Helvetica Neue', Helvetica, Arial, 'sans-serif';
+      box-sizing: border-box;
+      background-color: #777;
+      mso-line-height-rule: exactly;
+    }
+    h1 {
+      margin: 0;
+    }
+    table.layout {
+      border: none;
+      border-radius: 4px;
+      background-color: white;
+      width: 600px;
+      margin: auto;
+      border-collapse: collapse;
+    }
+    td.layout {
+      padding: 1em;
+      mso-line-height-rule: exactly;
+    }
+    span.italic-grey {
+      font-style: italic;
+      color: #777;
+    }
+    p.english-version {
+      font-style: italic;
+      color: #777;
+      display: inline-block;
+      margin: 2em 0 1em 0;
+    }
+    table.header {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      border-radius: 0;
+      margin: 0;
+    }
+    table.main-table {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border-radius: 0;
+      border: none;
+      margin: 0;
+      line-height: 1.8em;
+    }
+    table.footer {
+      border-collapse: collapse;
+      border-spacing: 0;
+      border: none;
+      border-radius: 0;
+      margin: 0;
+      font-size: 0.8em;
+      color: #777;
+      width: 100%;
+    }
+    td.with-top-bottom-padding {
+      padding: 0.8em 0;
+    }
+    td.italic {
+      font-style: italic;
+      padding: 0;
+    }
+    td.footer-left {
+      font-style: italic;
+    }
+    td.footer-right {
+      text-align: right;
+    }
+    a.link-button {
+      font-size: 0.8em;
+      background-color: #f0690a;
+      text-decoration: none;
+      padding: 0.2em 0.8em;
+      color: white;
+      display: inline-block;
+      border-radius: 4px;
+      mso-padding-alt: 0;
+      text-underline-color: #f0690a;
+      border: 2px solid #f0690a;
+    }
+    a.link-button:hover {
+      background-color: white;
+      color: #f0690a;
+    }
+  </style>
+</head>
+<body>
+<table class="layout">
+  <tbody>
+  <tr>
+    <td class="layout">
+      <header>
+        <table class="header">
+          <tbody>
+          <tr>
+            <td>
+              <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2014/06/D4K_QUEBEC_1000px.png"
+                   alt="Devoxx4Kids Québec logo"
+                   width="560"
+                   style="width: 560px; margin: auto;" />
+            </td>
+          </tr>
+          <tr>
+            <td><span class="italic-grey">Devoxx4Kids Québec</span></td>
+          </tr>
+          <tr>
+            <td style="padding: 1.8em 0;">
+              <h1>Vous y êtes presque ! / You're almost there!</h1></td>
+          </tr>
+          <tr>
+            <td><span class="italic-grey">The English version will follow</span></td>
+          </tr>
+          </tbody>
+        </table>
+      </header>
+    </td>
+  </tr>
+  <tr>
+    <td class="layout">
+      <main>
+        <table class="main-table" lang="fr-CA" xml:lang="fr-CA">
+          <tbody>
+          <tr>
+            <td>Bonjour booker-firstName booker-lastName,</td>
+          </tr>
+          <tr>
+            <td>Merci de votre intérêt pour notre prochain événement !</td>
+          </tr>
+          <tr>
+            <td>Si c'est bien vous qui souhaitez réserver une activité, merci d'utiliser le lien suivant :</td>
+          </tr>
+          <tr>
+            <td class="with-top-bottom-padding">
+              <a href="base_url/bookings/signature" class="link-button" target="_blank">
+                <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+                Réserver une activité
+                <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td class="italic">Après avoir cliqué sur ce lien, vous pourrez inscrire votre(vos) enfant(s) aux différentes activités du prochain événement</td>
+          </tr>
+          <tr>
+            <td class="italic">L'équipe Devoxx4Kids Québec</td>
+          </tr>
+          </tbody>
+        </table>
+        <p class="english-version">English version:</p>
+        <table class="main-table" lang="en-CA" xml:lang="en-CA">
+          <tbody>
+          <tr>
+            <td>Hi booker-firstName booker-lastName,</td>
+          </tr>
+          <tr>
+            <td>Thanks for your interest for our next event!</td>
+          </tr>
+          <tr>
+            <td>If it was you who wanted to book an activity, then please use the following link:</td>
+          </tr>
+          <tr>
+            <td class="with-top-bottom-padding">
+              <a href="base_url/bookings/signature" class="link-button" target="_blank">
+                <!--[if mso]><i style="mso-font-width:80%;mso-text-raise:40%" hidden>&emsp;</i><span style="mso-text-raise:20%;"><![endif]-->
+                Book an activity
+                <!--[if mso]></span><i style="mso-font-width:80%;" hidden>&emsp;&#8203;</i><![endif]-->
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td class="italic">After you click on the link, you'll be able to book activities for your child(ren)</td>
+          </tr>
+          <tr>
+            <td class="italic">The Devoxx4Kids Québec team</td>
+          </tr>
+          <tr>
+            <td style="padding: 0; line-height: 1em;">&nbsp;</td>
+          </tr>
+          </tbody>
+        </table>
+      </main>
+    </td>
+  </tr>
+  <tr>
+    <td class="layout">
+      <footer>
+        <table class="footer">
+          <tbody>
+          <tr>
+            <td class="footer-left">© 2025 Québec – All rights reserved</td>
+            <td class="footer-right">
+              <table style="border: none; border-spacing: 0; border-collapse: collapse; margin: auto 0 auto auto; width: 100px;">
+                <tbody>
+                <tr>
+                  <td>
+                    <a href="https://www.facebook.com/Devoxx4KidsQC/">
+                      <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2024/11/facebook-300x300.png"
+                           alt="Facebook logo"
+                           width="32"
+                           height="32"
+                           style="display: inline; width: 32px;"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a href="https://www.linkedin.com/company/devoxx4kids-quebec/?viewAsMember=true">
+                      <img src="https://www.devoxx4kids.org/quebec/wp-content/uploads/sites/12/2024/11/linkedin-300x300.png"
+                           alt="LinkedIn logo"
+                           width="32"
+                           height="32"
+                           style="display: inline; width: 32px;"
+                      />
+                    </a>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </footer>
+    </td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/test/resources/email/returning_booker.txt
+++ b/src/test/resources/email/returning_booker.txt
@@ -1,0 +1,18 @@
+Devoxx4Kids Québec, dernière étape avant de réserver une activité (English version will follow):
+
+Bonjour booker-firstName booker-lastName,
+Merci de votre intérêt pour notre prochain événement !
+Si c'est bien vous qui souhaitez réserver une activité, merci d'utiliser le lien suivant : base_url/bookings/signature
+
+Après avoir cliqué sur ce lien, vous pourrez inscrire votre(vos) enfant(s) aux différentes activités du prochain événement.
+L'équipe Devoxx4Kids Québec.
+
+English version:
+Devoxx4Kids Québec, last step before booking an activity:
+
+Hi booker-firstName booker-lastName,
+Thanks for your interest for our next event!
+If it was you who wanted to book an activity, then please use the following link: base_url/bookings/signature
+
+After you click on the link, you'll be able to book activities for your child(ren).
+The Devoxx4Kids Québec team.


### PR DESCRIPTION
Following [this discussion about the use of `email` as `PK` for `Booker`](https://github.com/montrealjug/billetterie/discussions/33), here is a `PR` implementing my proposal.

Its behaviour is shown in the following gif:

![gif describing the new Booking flow](https://github.com/user-attachments/assets/92b6367a-3ca5-4ca1-a40f-b3e52a94888b)

On top of changes needed, I've made other changes in `RegistrationController`.

This `PR` also introduces `rest-assured` as a clean way to test our web layer. This has been used to validate the affected portion of the `RegistrationController`. See `RegistrationControllerTest` for details.