### PR TITLE
feat: add secrurity for admin and actuator

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,13 @@ openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:204
 ```
 
 then set the env. variable / secret `APP_RSA_KEY`
+
+### Configure security
+
+Set at least those environment variables:
+* `ACTUATOR_PASSWORD`, defaults to `actuator` 😱😉
+* `ADMIN_PASSWORD`, defaults to `password` 😱😉
+
+You can also set:
+* `ADMIN_USER`, defaults to `admin` to... set the `admin` username
+* `ADMIN_SESSION_COOKIE_NAME`, defaults to `BILLETTERIE_SESSION` to ... set the `admin` session cookie name

--- a/fly.toml
+++ b/fly.toml
@@ -14,6 +14,15 @@ primary_region = 'yul'
   min_machines_running = 1
   max_machines_running = 1
   processes = ['app']
+  [[http_service.checks]]
+    grace_period = "40s"
+    interval = "1m0s"
+    method = "GET"
+    path = "/readyz"
+    timeout = "5s"
+    protocol = "http"
+    [http_service.checks.headers]
+      X-Forwarded-Proto = "https"
 
 [[vm]]
   memory = '1gb'

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>gg.jte</groupId>
 			<artifactId>jte-spring-boot-starter-3</artifactId>
 			<version>${jte.version}</version>

--- a/src/main/java/org/montrealjug/billetterie/security/AdminLoginController.java
+++ b/src/main/java/org/montrealjug/billetterie/security/AdminLoginController.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.montrealjug.billetterie.security;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.view.RedirectView;
+
+@Controller
+public class AdminLoginController {
+
+    @GetMapping("/admin/login")
+    public String login() {
+        return "login";
+    }
+
+    @PostMapping("/login-failed")
+    public RedirectView loginFailed() {
+        return new RedirectView("/");
+    }
+}

--- a/src/main/java/org/montrealjug/billetterie/security/SecurityConfiguration.java
+++ b/src/main/java/org/montrealjug/billetterie/security/SecurityConfiguration.java
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.montrealjug.billetterie.security;
+
+import jakarta.servlet.SessionTrackingMode;
+import java.util.Set;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration(proxyBeanMethods = false)
+@EnableWebSecurity
+@EnableConfigurationProperties(SecurityConfiguration.AdminProperties.class)
+public class SecurityConfiguration {
+
+    private static final String ADMIN_ROLE = "admin";
+    private static final String ACTUATOR_ROLE = "actuator";
+
+    // we define the basic auth for actuator before
+    // to avoid clash between our security chains, we have to use `securityMatcher`
+    // to scope this security chain on the `actuator/**` path only.
+    // as `actuator` is `read-only` in the config, we have a small risk of csrf:
+    // an attacker could forge a link that, if clicked by a user with saved `actuator`
+    // credentials in their browser, could leak some info.
+    // as `threaddump` and `heapdump` are also disabled, I think we can live
+    // with the threat of leaking our `beans` hierarchy or our `loggers` config
+    @Bean
+    @Order(0)
+    SecurityFilterChain actuatorBasicAuth(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .securityMatchers(
+                        securityMatcher -> securityMatcher.requestMatchers("/actuator/**"))
+                .authorizeHttpRequests(
+                        authorizationRequests ->
+                                authorizationRequests.anyRequest().hasRole(ACTUATOR_ROLE))
+                .httpBasic(httpBasic -> httpBasic.realmName("actuator realm"))
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .build();
+    }
+
+    // quick note on csrf
+    // we are safe because:
+    // - we do set `SameSite: Strict` on our session cookie
+    // - we do set a `path` to `/admin` on our session cookie
+    // - we do not have mutations done via `safe` methods
+    // - we do not use `javascript` outside of simple vanilla scripts inlined in our pages
+    // we should enhance our solution by signing our session cookie in order to mitigate an attacker
+    // trying to guess, by brute force a valid session-id... but this is kind of overkill for us
+    // and could be done later in another `PR`
+    // for more on CSRF:
+    // https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+    @Bean
+    @Order(1)
+    SecurityFilterChain appSecurityFilterChain(HttpSecurity http, AdminProperties adminProperties)
+            throws Exception {
+        return http.authorizeHttpRequests(
+                        authorizeRequests ->
+                                authorizeRequests
+                                        .requestMatchers("/admin/**")
+                                        .hasRole(ADMIN_ROLE)
+                                        // we can authorize everything else,
+                                        // as `/actuator/**` is handled first
+                                        .anyRequest()
+                                        .permitAll())
+                .formLogin(
+                        loginForm ->
+                                loginForm
+                                        .loginPage("/admin/login")
+                                        .defaultSuccessUrl("/admin/events")
+                                        .failureForwardUrl("/login-failed")
+                                        .permitAll())
+                .logout(
+                        logout ->
+                                logout.clearAuthentication(true)
+                                        .invalidateHttpSession(true)
+                                        .logoutUrl("/admin/logout")
+                                        .logoutSuccessUrl("/")
+                                        .deleteCookies(adminProperties.sessionCookieName()))
+                .sessionManagement(
+                        session ->
+                                session.sessionConcurrency(
+                                        concurrency -> concurrency.expiredUrl("/")))
+                .csrf(AbstractHttpConfigurer::disable)
+                // no need for CORS for our `app`, so let's be sure its forbidden
+                .cors(AbstractHttpConfigurer::disable)
+                .build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    UserDetailsService userDetailsService(
+            PasswordEncoder passwordEncoder, AdminProperties adminProperties) {
+        var adminPassword = passwordEncoder.encode(adminProperties.adminPassword());
+        var adminUser =
+                User.builder()
+                        .username(adminProperties.adminUsername())
+                        .password(adminPassword)
+                        .roles(ADMIN_ROLE)
+                        .build();
+        var actuatorPassword = passwordEncoder.encode(adminProperties.actuatorPassword());
+        var actuatorUser =
+                User.builder()
+                        .username(adminProperties.actuatorUsername())
+                        .password(actuatorPassword)
+                        .roles(ACTUATOR_ROLE)
+                        .build();
+        return new InMemoryUserDetailsManager(adminUser, actuatorUser);
+    }
+
+    // There are properties in server.servlet.session.cookie namespace that can (should?) be used,
+    // but setting stuff by code makes it easier to test, as it's not in the `application.yml`
+    // currently we don't have a dedicated profile for `test`,
+    // so we can't test the values in our `application.yml` used for `prod`
+    @Bean
+    ServletContextInitializer securityInitializer(AdminProperties adminProperties) {
+        return sc -> {
+            // disable session identification by URL by forcing Cookie only
+            sc.setSessionTrackingModes(Set.of(SessionTrackingMode.COOKIE));
+            var sessionCookieConfig = sc.getSessionCookieConfig();
+            sessionCookieConfig.setHttpOnly(true);
+            sessionCookieConfig.setSecure(true);
+            sessionCookieConfig.setName(adminProperties.sessionCookieName());
+            // only set Cookie for `/admin` (our authenticated path)
+            sessionCookieConfig.setPath("/admin");
+            // enforce SameSite: Strict to avoid dealing with csrf
+            sessionCookieConfig.setAttribute("SameSite", Cookie.SameSite.STRICT.attributeValue());
+        };
+    }
+
+    @ConfigurationProperties(prefix = "app.admin")
+    record AdminProperties(
+            String adminUsername,
+            String adminPassword,
+            String sessionCookieName,
+            String actuatorPassword) {
+
+        String actuatorUsername() {
+            return "actuator";
+        }
+    }
+}

--- a/src/main/jte/layouts/admin_layout.jte
+++ b/src/main/jte/layouts/admin_layout.jte
@@ -24,6 +24,9 @@
     <div>
         <a href="/" class="hover:text-gray-700">Go to main website</a>
     </div>
+    <div>
+        <a href="/admin/logout" class="hover:text-gray-700">Logout</a>
+    </div>
 </nav>
 </header>
 <main class="grow-1">

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,8 +43,16 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        add-additional-paths: on
+        enabled: on
 
 app:
+  admin:
+    actuator-password: ${ACTUATOR_PASSWORD:actuator} # the user is hardcoded as `actuator`
+    admin-username: ${ADMIN_USER:admin}
+    admin-password: ${ADMIN_PASSWORD:password}
+    session-cookie-name: ${ADMIN_SESSION_COOKIE_NAME:BILLETTERIE_SESSION} # we name the cookie, for fun and to clean it
   mail:
     from:
       address: devoxx4kidsqc@montreal-jug.org

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,6 +23,11 @@ gg:
 
 # required for email configuration
 app:
+  admin:
+    actuator-password: actuator
+    admin-username: admin
+    admin-password: password
+    session-cookie-name: BILLETTERIE_SESSION
   mail:
     from:
       address: "from@test.org"


### PR DESCRIPTION
Add `spring-security` to secure both `admin` and `actuator`

There is a dedicated user for each access to avoid that leaking one leaks the other one.

## For Admin
- `username` is configurable with `$ADMIN_USER` (defaults to `admin`)
- `password` is configurable with `$ADMIN_PASSWORD` (defaults to `password`)

Admin is secured via a form + session-cookie.  
As we have just one instance in prod, nothing to setup for stickiness or replication   
The session-cookie name is configurable via `${ADMIN_SESSION_COOKIE_NAME}` and defaults to `BILLETTERIE_SESSION`.  
This session-cookie is:
- `secure` (so `https` only, except for `localhost`) 
- `httpOnly` (so not accessible from `javascript`)
- scoped on path `/admin` (to send it only when necessary)
- `SameSite: Strict` (to mitigate csrf)

## For actuator
- `username` is `actuator` and can not be changed
- `password` is configurable with `$ACTUATOR_PASSWORD` (defaults to `actuator`)

Actuator is secured via basic-auth, without `csrf` protection... but we have also have set it up with `read_only` and removed the most sensitive endpoints (`threaddump` and `heapdump`). I think we can live with the risk of someone trying to forge a link that will reuse saved credentials in a browser to read our `beans` hierarchy or our `logs` configuration...

There's a note on `csrf` and why we are safe  for `admin` and a little exposed for `actuator` in `SecurityConfiguration`

All the behaviours are tested in `SecurityTest` with `rest-assured`.

closes #44 