### PR TITLE
feat: create template layouts and add visual improvements

### DIFF
--- a/src/main/jte/activities-create-update.jte
+++ b/src/main/jte/activities-create-update.jte
@@ -2,16 +2,11 @@
 @param Long eventId
 @param String errorMessage
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Create New Activity</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100">
-<div class="min-h-screen flex items-center justify-center">
+@template.layouts.admin_layout(
+title = "${activity != null ? \"Update\" : \"Create\"} Activity",
+content = @`
+<div class="min-h-screen flex flex-col items-center justify-center">
+    <a href="/admin/events" class="text-blue text-gray w-full max-w-md">&lt;&lt;&lt; Back</a>
     <div class="bg-white p-8 rounded shadow-md w-full max-w-md">
         @if(errorMessage != null)
             <div class="mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
@@ -66,5 +61,4 @@
         @endif
     </div>
 </div>
-</body>
-</html>>
+`)

--- a/src/main/jte/booker-activities.jte
+++ b/src/main/jte/booker-activities.jte
@@ -12,17 +12,9 @@
 @param Map<Long, List<Participant>> activityParticipants = null
 @param Map<Long, Integer> activityTotalParticipants = null
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Event Activities</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100">
-<a href="/admin/events">Go to the admin page</a>
-
+@template.layouts.guest_layout(
+title = "Event Activities",
+content = @`
 <div class="min-h-screen flex flex-col items-center justify-center">
     @if(error != null)
         <div class="bg-red-500 text-white p-4 mb-4 rounded-md w-full max-w-4xl">
@@ -95,6 +87,9 @@
             </div>
         @endif
     </div>
+
+</div>
+`)
 
     <script>
         // Store booker email signature in a JavaScript variable
@@ -218,6 +213,4 @@
             }
         }
     </script>
-</div>
-</body>
-</html>
+

--- a/src/main/jte/booker-activities.jte
+++ b/src/main/jte/booker-activities.jte
@@ -56,7 +56,7 @@ content = @`
                                     <td class="border border-gray-300 px-4 py-2">${activity.time().format(DateTimeFormatter.ofPattern("H:mm a"))}</td>
                                     <td class="border border-gray-300 px-4 py-2">
                                         <button onclick="displayParticipantModal(${activity.id()})" 
-                                                class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600 focus:outline-none focus:ring focus:ring-green-300">
+                                                class="bg-[#e16309] text-white px-3 py-1 rounded hover:opacity-80 focus:outline-none focus:ring focus:ring-orange-300">
                                             Add participant
                                         </button>
                                     </td>
@@ -123,7 +123,7 @@ content = @`
                 <div id="error-message" class="text-red-500 text-sm hidden"></div>
                 <div class="flex justify-end gap-2">
                     <button type="button" onclick="closeModal()" class="bg-gray-300 text-gray-700 px-3 py-1 rounded hover:bg-gray-400 focus:outline-none focus:ring">Cancel</button>
-                    <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300">Submit</button>
+                    <button type="submit" class="bg-[#ee7c2a] text-white px-3 py-1 rounded hover:opacity-80 focus:outline-none focus:ring focus:ring-blue-300">Submit</button>
                 </div>
             </form>
         </div>

--- a/src/main/jte/bookers-create-update.jte
+++ b/src/main/jte/bookers-create-update.jte
@@ -1,16 +1,12 @@
 @param org.montrealjug.billetterie.ui.PresentationBooker booker = null
 @param String errorMessage = null
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Manage Bookers</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100">
-<div class="min-h-screen flex items-center justify-center">
+@template.layouts.admin_layout(
+title = "${booker != null ? \"Add\" : \"Modify\"} Booker",
+content = @`
+
+<div class="min-h-screen flex flex-col items-center justify-center">
+    <a href="/admin/bookers" class="text-blue text-gray w-full max-w-md">&lt;&lt;&lt; Back</a>
     <div class="bg-white p-8 rounded shadow-md w-full max-w-md">
         @if(errorMessage != null)
             <h2 class="text-red-500">${errorMessage}</h2>
@@ -62,6 +58,5 @@
     </div>
 
 </div>
-</body>
-</html>
+`)
 

--- a/src/main/jte/bookers-list.jte
+++ b/src/main/jte/bookers-list.jte
@@ -3,20 +3,11 @@
 
 @param List<PresentationBooker> bookerList
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Booker List</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100">
-<a href="/admin/events">Go to the events admin page</a>
+@template.layouts.admin_layout(title = "Booker List",content = @`
+
 <div class="min-h-screen flex flex-col items-center justify-center">
 
-
-    <div>
+    <div class="bg-white p-8 rounded shadow-md w-full max-w-4xl">
         <div class="flex flex-col items-center mb-6">
             <h1 class="text-2xl font-bold">Booker List</h1>
             <p>Total number of bookers: ${bookerList.size()}</p>
@@ -37,5 +28,4 @@
         @endfor
     </div>
 </div>
-</body>
-</html>
+`)

--- a/src/main/jte/events-create-update.jte
+++ b/src/main/jte/events-create-update.jte
@@ -4,16 +4,11 @@
 
 @param String errorMessage
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Create New Event</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100">
-<div class="min-h-screen flex items-center justify-center">
+@template.layouts.admin_layout(
+title = "${event != null ? \"Create\" : \"Update\"} Event" ,
+content = @`
+<div class="min-h-screen flex flex-col items-center justify-center">
+    <a href="/admin/events" class="text-blue text-gray w-full max-w-md">&lt;&lt;&lt; Back</a>
     <div class="bg-white p-8 rounded shadow-md w-full max-w-md">
 
         @if(errorMessage != null)
@@ -66,5 +61,4 @@
         @endif
     </div>
 </div>
-</body>
-</html>
+`)

--- a/src/main/jte/events-list.jte
+++ b/src/main/jte/events-list.jte
@@ -4,22 +4,10 @@
 @import java.util.List
 
 @param List<PresentationEvent> events
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Event List</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100">
-<a href="/">Go to the main page</a>
-<a href="/admin/bookers">Go to the bookers admin page</a>
 
-<div class="min-h-screen flex flex-col items-center justify-center">
+@template.layouts.admin_layout(title = "Event List", content = @`
 
-
-    <div class="min-h-screen flex flex-col items-center justify-center">
+    <div class="min-h-screen flex flex-col items-center justify-center my-100">
         <div class="bg-white p-8 rounded shadow-md w-full max-w-4xl">
             <!-- Create Event Button -->
             <div class="flex justify-between items-center mb-6">
@@ -94,7 +82,7 @@
                     </table>
                     <!-- Create Activity Button -->
                     <div class="text-right mt-2">
-                        <button onclick="window.location.href = `/admin/events/${event.id()}/createActivity`"
+                        <button onclick="window.location.href = '/admin/events/${event.id()}/createActivity'"
                                 class="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600 focus:outline-none focus:ring focus:ring-green-300">
                             Add Activity
                         </button>
@@ -104,7 +92,7 @@
             @endfor
         </div>
     </div>
-
+`)
     <script>
 @raw
     async function deleteEvent(eventId) {
@@ -196,8 +184,3 @@
         <%--    // Redirect to a form or handle activity creation logic--%>
         <%--}--%>
     </script>
-
-
-</div>
-</body>
-</html>

--- a/src/main/jte/index.jte
+++ b/src/main/jte/index.jte
@@ -72,10 +72,15 @@ content = @`
 
                     </div>
                 </div>
-                <button id="register-button" onclick="displayRegistrationModal()"
-                        class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300">
-                    Register
-                </button>
+
+                <br>
+                <div class="flex justify-end">
+                    <button id="register-button" onclick="displayRegistrationModal()"
+                            class="bg-[#ee7c2a] text-white px-3 py-2 rounded border hover:opacity-80 focus:outline-none focus:ring focus:ring-orange-300">
+                        Register
+                    </button>
+                </div>
+
                 <div id="success-registration-message" class="mt-4 p-4 bg-green-100 text-green-700 rounded-md hidden">
                     You have successfully registered your email address, please check your inbox and click on the verification link to register your kids to the activities
                 </div>
@@ -117,7 +122,7 @@ content = @`
                     <p id="error-message" class="text-red-500 text-sm hidden"></p>
                     <div class="flex justify-end gap-2">
                         <button type="button" onclick="closeModal()" class="bg-gray-300 text-gray-700 px-3 py-1 rounded hover:bg-gray-400 focus:outline-none focus:ring">Cancel</button>
-                        <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300">Submit</button>
+                        <button type="submit" class="bg-[#ee7c2a] text-white px-3 py-1 rounded hover:opacity-80 focus:outline-none focus:ring focus:ring-orange-300">Submit</button>
                     </div>
                 </form>
             </div>

--- a/src/main/jte/index.jte
+++ b/src/main/jte/index.jte
@@ -5,16 +5,9 @@
 @param PresentationEvent event = null
 @param String error = null
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Event List</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100">
-<a href="/admin/events">Go to the events admin page</a>
+@template.layouts.guest_layout(
+title = "Welcome",
+content = @`
 
 <div class="min-h-screen flex flex-col items-center justify-center">
     @if(error != null)
@@ -93,19 +86,22 @@
 
         @else
             <div class="bg-white p-8 rounded shadow-md w-full max-w-4xl">
-                There is no event planned currrently
+                There is no event planned currently
             </div>
         @endif
 
     </div>
 
-    <script>
-        function displayRegistrationModal() {
-            // Create the modal elements
-            const modal = document.createElement("div");
-            modal.id = "registration-modal";
-            modal.className = "fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50";
-            modal.innerHTML = `
+</div>
+`)
+
+<script>
+    function displayRegistrationModal() {
+        // Create the modal elements
+        const modal = document.createElement("div");
+        modal.id = "registration-modal";
+        modal.className = "fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50";
+        modal.innerHTML = `
             <div class="bg-white rounded-lg shadow-md p-6 w-96">
                 <h2 class="text-lg font-semibold text-gray-800 mb-4">Register</h2>
                 <p id="first-registration-message" class="text-gray-800 text-sm mb-4 hidden">
@@ -126,22 +122,22 @@
                 </form>
             </div>
             `;
-            // add the modal in DOM
-            document.body.appendChild(modal);
-            const form = modal.querySelector("#registration-form");
-            form.addEventListener("submit", onRegistrationFormSubmit);
-        }
+        // add the modal in DOM
+        document.body.appendChild(modal);
+        const form = modal.querySelector("#registration-form");
+        form.addEventListener("submit", onRegistrationFormSubmit);
+    }
 
-        function closeModal() {
-            const modal = document.getElementById("registration-modal");
-            if (modal) {
-                modal.remove();
-            }
+    function closeModal() {
+        const modal = document.getElementById("registration-modal");
+        if (modal) {
+            modal.remove();
         }
+    }
 
-        function displayFullRegistrationForm(form, email) {
-            const fieldSet = form.querySelector("fieldset");
-            fieldSet.innerHTML = `
+    function displayFullRegistrationForm(form, email) {
+        const fieldSet = form.querySelector("fieldset");
+        fieldSet.innerHTML = `
             <div>
                 <label for="first-name" class="block text-gray-700">First Name</label>
                 <input type="text" id="first-name" name="firstName" class="border border-gray-300 rounded px-3 py-2 w-full" required>
@@ -159,112 +155,109 @@
                 <input type="email" id="confirm-email" name="confirmEmail" class="border border-gray-300 rounded px-3 py-2 w-full" required>
             </div>
             `;
-            form.email.value = email;
-            form.parentElement.querySelector("#first-registration-message").classList.remove("hidden");
-        }
+        form.email.value = email;
+        form.parentElement.querySelector("#first-registration-message").classList.remove("hidden");
+    }
 
-        async function onRegistrationFormSubmit(event) {
-            event.preventDefault();
-            const form = event.target;
-            const errorMessage = form.querySelector("#error-message");
-            errorMessage.classList.add("hidden");
-            const isFullRegistration = form.querySelector("#confirm-email") !== null;
-            if (isFullRegistration) {
-                await registerNewBooker(form, errorMessage);
-            } else {
-                await checkReturningBooker(form, errorMessage);
-            }
+    async function onRegistrationFormSubmit(event) {
+        event.preventDefault();
+        const form = event.target;
+        const errorMessage = form.querySelector("#error-message");
+        errorMessage.classList.add("hidden");
+        const isFullRegistration = form.querySelector("#confirm-email") !== null;
+        if (isFullRegistration) {
+            await registerNewBooker(form, errorMessage);
+        } else {
+            await checkReturningBooker(form, errorMessage);
         }
+    }
 
-        async function checkReturningBooker(form, errorMessage) {
-            const email = form.email.value.trim();
-            if (!email) {
-                errorMessage.textContent = "Please provide an email address.";
-                errorMessage.classList.remove("hidden");
-                return;
-            }
-            try {
-                const response = await fetch("/check-returning-booker", {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ email }),
-                });
-                switch (response.status) {
-                    case 204:
-                        onRegistrationCompleted("returning");
-                        break;
-                    case 404:
-                        displayFullRegistrationForm(form, email);
-                        break;
-                    default:
-                        console.error("unexpected status code: " + response.status);
-                        errorMessage.textContent = "An error occurred. Please try again.";
-                        errorMessage.classList.remove("hidden");
-                        break;
-                }
-            } catch (error) {
-                console.error("Error during registration:", error);
-                errorMessage.textContent = "An error occurred. Please try again.";
-                errorMessage.classList.remove("hidden");
-            }
+    async function checkReturningBooker(form, errorMessage) {
+        const email = form.email.value.trim();
+        if (!email) {
+            errorMessage.textContent = "Please provide an email address.";
+            errorMessage.classList.remove("hidden");
+            return;
         }
-
-        async function registerNewBooker(form, errorMessage) {
-            // Gather form data
-            const firstName = form.firstName.value.trim();
-            const lastName = form.lastName.value.trim();
-            const email = form.email.value.trim();
-            const confirmEmail = form.confirmEmail.value.trim();
-            // Validate inputs
-            if (!firstName || !lastName || !email || !confirmEmail) {
-                errorMessage.textContent = "Please fill in all fields.";
-                errorMessage.classList.remove("hidden");
-                return;
-            }
-            if (email !== confirmEmail) {
-                errorMessage.textContent = "Emails do not match.";
-                errorMessage.classList.remove("hidden");
-                return;
-            }
-            // Send HTTP POST request
-            try {
-                const response = await fetch("/register-booker", {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ firstName, lastName, email }),
-                });
-                if (response.ok) {
-                    onRegistrationCompleted("registration");
-                } else {
-                    const errorData = await response.json();
-                    errorMessage.textContent = errorData.message || "Registration failed.";
+        try {
+            const response = await fetch("/check-returning-booker", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ email }),
+            });
+            switch (response.status) {
+                case 204:
+                    onRegistrationCompleted("returning");
+                    break;
+                case 404:
+                    displayFullRegistrationForm(form, email);
+                    break;
+                default:
+                    console.error("unexpected status code: " + response.status);
+                    errorMessage.textContent = "An error occurred. Please try again.";
                     errorMessage.classList.remove("hidden");
-                }
-            } catch (error) {
-                console.error("Error during registration:", error);
-                errorMessage.textContent = "An error occurred. Please try again.";
+                    break;
+            }
+        } catch (error) {
+            console.error("Error during registration:", error);
+            errorMessage.textContent = "An error occurred. Please try again.";
+            errorMessage.classList.remove("hidden");
+        }
+    }
+
+    async function registerNewBooker(form, errorMessage) {
+        // Gather form data
+        const firstName = form.firstName.value.trim();
+        const lastName = form.lastName.value.trim();
+        const email = form.email.value.trim();
+        const confirmEmail = form.confirmEmail.value.trim();
+        // Validate inputs
+        if (!firstName || !lastName || !email || !confirmEmail) {
+            errorMessage.textContent = "Please fill in all fields.";
+            errorMessage.classList.remove("hidden");
+            return;
+        }
+        if (email !== confirmEmail) {
+            errorMessage.textContent = "Emails do not match.";
+            errorMessage.classList.remove("hidden");
+            return;
+        }
+        // Send HTTP POST request
+        try {
+            const response = await fetch("/register-booker", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ firstName, lastName, email }),
+            });
+            if (response.ok) {
+                onRegistrationCompleted("registration");
+            } else {
+                const errorData = await response.json();
+                errorMessage.textContent = errorData.message || "Registration failed.";
                 errorMessage.classList.remove("hidden");
             }
+        } catch (error) {
+            console.error("Error during registration:", error);
+            errorMessage.textContent = "An error occurred. Please try again.";
+            errorMessage.classList.remove("hidden");
         }
+    }
 
-        function onRegistrationCompleted(registrationType) {
-            closeModal();
-            @raw
-            const successMessageId = `success-${registrationType}-message`;
-            @endraw
-            // Show success message
-            const successMessage = document.getElementById(successMessageId);
-            successMessage.classList.remove("hidden");
-            // Disable register button
-            const registerButton = document.getElementById("register-button");
-            registerButton.disabled = true;
-            registerButton.classList.add("opacity-50", "cursor-not-allowed");
-        }
-    </script>
-</div>
-</body>
-</html>
+    function onRegistrationCompleted(registrationType) {
+        closeModal();
+        @raw
+        const successMessageId = `success-${registrationType}-message`;
+        @endraw
+        // Show success message
+        const successMessage = document.getElementById(successMessageId);
+        successMessage.classList.remove("hidden");
+        // Disable register button
+        const registerButton = document.getElementById("register-button");
+        registerButton.disabled = true;
+        registerButton.classList.add("opacity-50", "cursor-not-allowed");
+    }
+</script>

--- a/src/main/jte/index.jte
+++ b/src/main/jte/index.jte
@@ -6,7 +6,7 @@
 @param String error = null
 
 @template.layouts.guest_layout(
-title = "Welcome",
+title = "Event List",
 content = @`
 
 <div class="min-h-screen flex flex-col items-center justify-center">

--- a/src/main/jte/layouts/admin_layout.jte
+++ b/src/main/jte/layouts/admin_layout.jte
@@ -1,0 +1,29 @@
+@import gg.jte.Content
+
+@param String title
+@param Content content
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${title}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+
+<nav class="shadow-md p-4 bg-[#f78c40] w-full absolute">
+    <ul class="flex justify-center space-x-10">
+        <li><a href="/" class="hover:text-gray-700">Go to website</a></li>
+        <li><a href="/admin/events" class="hover:text-gray-700">Manage Event</a></li>
+        <li><a href="/admin/bookers" class="hover:text-gray-700">Manage Booker</a></li>
+    </ul>
+</nav>
+
+<div>
+    ${content}
+</div>
+
+</body>
+</html>

--- a/src/main/jte/layouts/admin_layout.jte
+++ b/src/main/jte/layouts/admin_layout.jte
@@ -13,12 +13,17 @@
 </head>
 <body class="bg-gray-100">
 
-<nav class="shadow-md p-4 bg-[#f78c40] w-full absolute">
+<nav class="shadow-md p-4 bg-[#f78c40] w-full absolute flex justify-between">
+    <div>
+        DEVOXX4KIDS Admin
+    </div>
     <ul class="flex justify-center space-x-10">
-        <li><a href="/" class="hover:text-gray-700">Go to website</a></li>
         <li><a href="/admin/events" class="hover:text-gray-700">Manage Event</a></li>
         <li><a href="/admin/bookers" class="hover:text-gray-700">Manage Booker</a></li>
     </ul>
+    <div>
+        <a href="/" class="hover:text-gray-700">Go to main website</a>
+    </div>
 </nav>
 
 <div>

--- a/src/main/jte/layouts/guest_layout.jte
+++ b/src/main/jte/layouts/guest_layout.jte
@@ -1,0 +1,35 @@
+@import gg.jte.Content
+
+@param String title
+@param Content content
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${title}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+
+<nav class="absolute shadow-md p-4 bg-[#f78c40] w-full flex justify-between">
+    <div>DEVOXX4KIDS LOGO</div>
+    <div><a href="/admin/events">TMP: Go to Admin page</a></div>
+</nav>
+
+<div>
+    ${content}
+</div>
+
+<footer>
+    <div>
+        <ul class="flex space-x-10 justify-center">
+            <li><a href="#">Privacy Policy</a></li>
+            <li><a href="#">Terms and Conditions</a></li>
+        </ul>
+    </div>
+</footer>
+</body>
+
+</html>

--- a/src/test/java/org/montrealjug/billetterie/ui/RegistrationControllerTest.java
+++ b/src/test/java/org/montrealjug/billetterie/ui/RegistrationControllerTest.java
@@ -328,7 +328,7 @@ class RegistrationControllerTest {
         assertThat((String) htmlPath.get("html.head.title")).isEqualTo("Event List");
         // check that the error msg is present
         // not ideal because coupled to the `html` structure but will do the job for now
-        var errorMsgNode = ((NodeChildren) htmlPath.get("html.body.div.div")).get(0);
+        var errorMsgNode = ((NodeChildren) htmlPath.get("html.body.div.div.div")).get(0);
         assertThat(errorMsgNode.getAttribute("id")).isEqualTo("main-error-message");
     }
 


### PR DESCRIPTION
Directly related to: #28 
 
This PR adds a public layout and an admin layout that add nav bar and footer to each page and extracts repeated elements to reduce boilerplate.

Some UI improvements are also applied to make the visual match closer to the Devoxx4Kids color scheme.

Note: due to the fact that all the html elements in the template syntax are wrapped in the "\@\`<valid html>\`" syntax, it means that we cannot use additional \`\`(back-tick) inside it. So we have to use double quote or single quote as much as possible, and for the case where absolutely need to use it (inside a <script> tag), we have to write the script outside of the template calling syntax, example:

```
@param User user

@template.layouts.admin_layout(titile="some title", content=@`
<h1>Hi</h1>
`)
<script>console.log("Hello `${user.getName()}`")</script>
```